### PR TITLE
fuzz: `program_result` as `u64`

### DIFF
--- a/fuzz/fixture/proto/invoke.proto
+++ b/fuzz/fixture/proto/invoke.proto
@@ -62,7 +62,7 @@ message InstrEffects {
     uint64 execution_time = 2;
 
     // Program return code. Zero is success, errors are non-zero.
-    uint32 program_result = 3;
+    uint64 program_result = 3;
 
     // The instruction return data.
     bytes return_data = 4;

--- a/fuzz/fixture/src/effects.rs
+++ b/fuzz/fixture/src/effects.rs
@@ -13,7 +13,7 @@ pub struct Effects {
     /// Execution time for instruction.
     pub execution_time: u64,
     // Program return code. Zero is success, errors are non-zero.
-    pub program_result: u32,
+    pub program_result: u64,
     pub return_data: Vec<u8>,
     /// Resulting accounts with state, to be checked post-simulation.
     pub resulting_accounts: Vec<(Pubkey, AccountSharedData)>,

--- a/harness/src/fuzz/mollusk.rs
+++ b/harness/src/fuzz/mollusk.rs
@@ -60,8 +60,8 @@ impl From<&InstructionResult> for FuzzEffects {
 
         let program_result = match &input.program_result {
             ProgramResult::Success => 0,
-            ProgramResult::Failure(e) => u64::from(e.clone()) as u32,
-            ProgramResult::UnknownError(_) => u32::MAX, //TODO
+            ProgramResult::Failure(e) => u64::from(e.clone()),
+            ProgramResult::UnknownError(_) => u64::MAX, //TODO
         };
 
         let resulting_accounts = input.resulting_accounts.clone();


### PR DESCRIPTION
### Problem

Currently, the `program_result` in the struct`Effects` is a `u32` value. But the built-in `InstructionError` values occupy the upper 32 bits – casting the resulting `u64` to `u32` effectively drops their value. The issue is apparent when the instruction fails with a `ProgramError::Custom(0)` and fixtures are generated. The result of the cast in this case be `0`, which is the same value as the `ProgramResult::Success`:
```rust
let program_result = match &program_result {
        ProgramResult::Success => 0,
        ProgramResult::Failure(e) => u64::from(e.clone()) as u32,
        ProgramResult::UnknownError(_) => u32::MAX, //TODO
};
```

### Solution

Update the value of `program_result` to be a `u64`.