### PR TITLE
harness: Clone accounts from transaction context instead of take

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -234,7 +234,8 @@ impl Mollusk {
                             let resulting_account = transaction_context
                                 .get_account_at_index(index)
                                 .unwrap()
-                                .take()
+                                .borrow()
+                                .clone()
                                 .into();
                             (*pubkey, resulting_account)
                         })


### PR DESCRIPTION
### Problem

When accounts are updated using the resulting accounts, accounts are taken from the `transaction_context` leaving an `Account::default()` on its place. When an instruction has multiple entries of the same account, the remaining "copies" of the account is updated with a default value.

### Solution

Replace the use of `take()` by `borrow().clone()`, so the correct value can be used for the remaining "copies" of the same account.