### PR TITLE
Fix clippy warning

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -94,7 +94,7 @@ fn search_paths(path: &str, extension: &str) -> Result<Vec<String>, Box<dyn std:
             for entry in fs::read_dir(path)? {
                 search_path_recursive(&entry?.path(), extension, result)?;
             }
-        } else if path.extension().map_or(false, |ext| ext == extension) {
+        } else if path.extension().is_some_and(|ext| ext == extension) {
             result.push(path.to_str().unwrap().to_string());
         }
         Ok(())


### PR DESCRIPTION
Fixes
```
warning: this `map_or` can be simplified
  --> cli/src/main.rs:97:19
   |
97 |         } else if path.extension().map_or(false, |ext| ext == extension) {
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
   = note: `#[warn(clippy::unnecessary_map_or)]` on by default
help: use is_some_and instead
   |
97 -         } else if path.extension().map_or(false, |ext| ext == extension) {
97 +         } else if path.extension().is_some_and(|ext| ext == extension) {
```