### PR TITLE
fix panic config

### DIFF
--- a/harness/src/result.rs
+++ b/harness/src/result.rs
@@ -108,10 +108,18 @@ impl Default for InstructionResult {
     }
 }
 
-#[derive(Default)]
 pub struct Config {
     pub panic: bool,
     pub verbose: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            panic: true,
+            verbose: false,
+        }
+    }
 }
 
 impl InstructionResult {

--- a/harness/tests/bpf_program.rs
+++ b/harness/tests/bpf_program.rs
@@ -151,7 +151,7 @@ fn test_transfer() {
         ],
         &[
             Check::success(),
-            Check::compute_units(2504),
+            Check::compute_units(2500),
             Check::account(&payer)
                 .lamports(payer_lamports - transfer_amount)
                 .build(),
@@ -209,7 +209,7 @@ fn test_close_account() {
         ],
         &[
             Check::success(),
-            Check::compute_units(2585),
+            Check::compute_units(2581),
             Check::account(&key)
                 .closed() // The rest is unnecessary, just testing.
                 .data(&[])
@@ -265,7 +265,7 @@ fn test_cpi() {
             &[
                 // This is the error thrown by SVM. It also emits the message
                 // "Program is not cached".
-                Check::err(ProgramError::InvalidAccountData),
+                Check::instruction_err(InstructionError::UnsupportedProgramId),
             ],
         );
     }
@@ -329,7 +329,7 @@ fn test_cpi() {
         ],
         &[
             Check::success(),
-            Check::compute_units(2288),
+            Check::compute_units(2289),
             Check::account(&key)
                 .data(data)
                 .lamports(lamports)


### PR DESCRIPTION
Mollusk offers a [`Config`](https://github.com/anza-xyz/mollusk/blob/dc74a633f442216ffbd899ba17a0432f7e78e60e/harness/src/result.rs#L111-L115) struct for configuring whether or not the harness should panic if a check fails, or simply chug along. This can be useful for scripted or server-side execution/verification scripts.

However, in the most common case, this panic should be enabled. Therefore, it should be part of `Default`.