### PR TITLE
CLI: clean up run-test stdout

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -176,9 +176,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 verbose,
             );
 
+            let mut failures = 0;
             for fixture_path in search_paths(&fixture, "fix")? {
-                runner.run(&mut mollusk_ground, Some(&mut mollusk_test), &fixture_path)?;
+                let result =
+                    runner.run(&mut mollusk_ground, Some(&mut mollusk_test), &fixture_path)?;
+                if !result {
+                    failures += 1;
+                }
             }
+
+            println!();
+            println!("[DONE][TEST RESULT]: {} failures", failures);
         }
     }
     Ok(())

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -71,7 +71,7 @@ impl Runner {
         ground: &mut Mollusk,
         target: Option<&mut Mollusk>,
         fixture_path: &str,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<bool, Box<dyn std::error::Error>> {
         // Disable stdout logging of program logs if not specified.
         if !self.program_logs {
             solana_logger::setup_with("");
@@ -110,7 +110,7 @@ impl Runner {
 
             let (target_result, _) = self.run_fixture(target, fixture_path);
 
-            if self.inputs_only || self.verbose {
+            if self.verbose {
                 println!("[TARGET]: RESULT:\n{:?}", &target_result);
             }
 
@@ -143,6 +143,6 @@ impl Runner {
             println!("FAIL: {}", &fixture_path);
         }
 
-        Ok(())
+        Ok(pass)
     }
 }


### PR DESCRIPTION
Cleans up the stdout of a `run-test` command, eliminating verbosity and allowing scripts to key on the final result stdout pattern.