### PR TITLE
bencher: add solana cli version to markdown

### DIFF
--- a/bencher/src/result.rs
+++ b/bencher/src/result.rs
@@ -19,7 +19,11 @@ impl<'a> MolluskComputeUnitBenchResult<'a> {
     }
 }
 
-pub(crate) fn write_results(out_dir: &Path, results: Vec<MolluskComputeUnitBenchResult>) {
+pub(crate) fn write_results(
+    out_dir: &Path,
+    solana_version: &str,
+    results: Vec<MolluskComputeUnitBenchResult>,
+) {
     let path = out_dir.join("compute_units.md");
 
     // Load the existing bench content and parse the most recent table.
@@ -34,7 +38,7 @@ pub(crate) fn write_results(out_dir: &Path, results: Vec<MolluskComputeUnitBench
         .map(|content| parse_last_md_table(content));
 
     // Prepare to write a new table.
-    let mut md_table = md_header();
+    let mut md_table = md_header(solana_version);
 
     // Evaluate the results against the previous table, if any.
     // If there are changes, write a new table.
@@ -76,15 +80,17 @@ pub(crate) fn write_results(out_dir: &Path, results: Vec<MolluskComputeUnitBench
     }
 }
 
-fn md_header() -> String {
+fn md_header(solana_version: &str) -> String {
     let now: DateTime<Utc> = Utc::now();
     format!(
         r#"#### Compute Units: {}
 
+Solana CLI Version: {}
+
 | Name | CUs | Delta |
 |------|------|-------|
 "#,
-        now
+        now, solana_version,
     )
 }
 


### PR DESCRIPTION
```md
#### Compute Units: 2025-03-19 14:46:09.862851780 UTC

Solana CLI Version: solana-cli 2.2.0 (src:8b11c7d5; feat:3294202862, client:Agave)

| Name | CUs | Delta |
|------|------|-------|
| bench0 | 44 | - new - |
| bench1 | 44 | - new - |
| bench2 | 44 | - new - |
| bench3 | 44 | - new - |
| bench4 | 44 | - new - |
| bench5 | 44 | - new - |
| bench6 | 44 | - new - |
```