### PR TITLE
cli: reorder ground and target parameters

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -157,8 +157,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let fixtures = search_paths(&fixture, "fix")?;
 
             Runner::new(checks, inputs_only, program_logs, proto, verbose).run_all(
-                &mut mollusk,
                 None,
+                &mut mollusk,
                 &fixtures,
             )?
         }
@@ -199,7 +199,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 proto,
                 verbose,
             )
-            .run_all(&mut mollusk_ground, Some(&mut mollusk_test), &fixtures)?
+            .run_all(Some(&mut mollusk_ground), &mut mollusk_test, &fixtures)?
         }
     }
     Ok(())


### PR DESCRIPTION
This was driving me nuts, as it was very confusing to follow. Now, both commands treat the provided binary as the "target", and `run-test` has the additive "ground truth".