### PR TITLE
cli: support generating cu reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,6 +1616,7 @@ version = "0.1.3"
 dependencies = [
  "clap",
  "mollusk-svm",
+ "mollusk-svm-bencher",
  "mollusk-svm-fuzz-fixture",
  "mollusk-svm-fuzz-fixture-firedancer",
  "serde",

--- a/bencher/src/lib.rs
+++ b/bencher/src/lib.rs
@@ -56,7 +56,7 @@
 //! | bench3 | 2,811 | +2,361 |
 //! ```
 
-mod result;
+pub mod result;
 
 use {
     mollusk_svm::{result::ProgramResult, Mollusk},
@@ -136,7 +136,7 @@ impl<'a> MolluskComputeUnitBencher<'a> {
     }
 }
 
-fn get_solana_version() -> String {
+pub fn get_solana_version() -> String {
     match Command::new("solana").arg("--version").output() {
         Ok(output) if output.status.success() => {
             String::from_utf8_lossy(&output.stdout).trim().to_string()

--- a/bencher/src/result.rs
+++ b/bencher/src/result.rs
@@ -7,7 +7,7 @@ use {
     std::path::Path,
 };
 
-pub(crate) struct MolluskComputeUnitBenchResult<'a> {
+pub struct MolluskComputeUnitBenchResult<'a> {
     name: &'a str,
     cus_consumed: u64,
 }
@@ -19,7 +19,7 @@ impl<'a> MolluskComputeUnitBenchResult<'a> {
     }
 }
 
-pub(crate) fn write_results(
+pub fn write_results(
     out_dir: &Path,
     solana_version: &str,
     results: Vec<MolluskComputeUnitBenchResult>,

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,7 @@ clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+mollusk-svm-bencher = { workspace = true }
 mollusk-svm-fuzz-fixture = { workspace = true }
 mollusk-svm-fuzz-fixture-firedancer = { workspace = true }
 mollusk-svm = { workspace = true, features = ["fuzz", "fuzz-fd", "serde"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -30,6 +30,9 @@ enum SubCommand {
         /// Path to the config file for validation checks.
         #[arg(short, long)]
         config: Option<String>,
+        /// Directory to write a compute unit consumption report.
+        #[arg(long)]
+        cus_report: Option<String>,
         /// Skip comparing compute unit consumption, but compare everything
         /// else.
         ///
@@ -72,6 +75,9 @@ enum SubCommand {
         /// Path to the config file for validation checks.
         #[arg(short, long)]
         config: Option<String>,
+        /// Directory to write a compute unit consumption report.
+        #[arg(long)]
+        cus_report: Option<String>,
         /// Skip comparing compute unit consumption, but compare everything
         /// else.
         ///
@@ -136,6 +142,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             fixture,
             program_id,
             config,
+            cus_report,
             ignore_compute_units,
             inputs_only,
             program_logs,
@@ -156,11 +163,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let fixtures = search_paths(&fixture, "fix")?;
 
-            Runner::new(checks, inputs_only, program_logs, proto, verbose).run_all(
-                None,
-                &mut mollusk,
-                &fixtures,
-            )?
+            Runner::new(
+                checks,
+                cus_report,
+                inputs_only,
+                program_logs,
+                proto,
+                verbose,
+            )
+            .run_all(None, &mut mollusk, &fixtures)?
         }
         SubCommand::RunTest {
             elf_path_source,
@@ -168,6 +179,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             fixture,
             program_id,
             config,
+            cus_report,
             ignore_compute_units,
             program_logs,
             proto,
@@ -194,6 +206,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             Runner::new(
                 checks,
+                cus_report,
                 /* inputs_only */ true,
                 program_logs,
                 proto,

--- a/harness/src/result.rs
+++ b/harness/src/result.rs
@@ -75,7 +75,7 @@ impl From<Result<(), InstructionError>> for ProgramResult {
 }
 
 /// The overall result of the instruction.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InstructionResult {
     /// The number of compute units consumed by the instruction.
     pub compute_units_consumed: u64,


### PR DESCRIPTION
Adds support for for generating a CU consumption report from the CLI, therefore from processing fixtures. Produces the same markdown file as a [CU bench test](https://github.com/solana-program/config/blob/5b7e1d775bdbcbba6e3df82afde923899793a0f3/program/benches/compute_units.md), where each bench run is the fixture name.