### PR TITLE
Allow In-Memory Benchmarks by Exposing Results and Skipping File Write

### DIFF
--- a/bencher/src/lib.rs
+++ b/bencher/src/lib.rs
@@ -65,7 +65,7 @@ use {
     solana_account::Account,
     solana_instruction::Instruction,
     solana_pubkey::Pubkey,
-    std::{path::PathBuf, process::Command},
+    std::{path::PathBuf, process::Command, str::FromStr},
 };
 
 /// A bench is a tuple of a name, an instruction, and a list of accounts.
@@ -119,6 +119,8 @@ impl<'a> MolluskComputeUnitBencher<'a> {
         let bench_results = std::mem::take(&mut self.benches)
             .into_iter()
             .map(|(name, instruction, accounts)| {
+                let logger = self.mollusk.logger.clone();
+                let log_idx = logger.as_ref().map(|logger| logger.borrow().messages.len());
                 let result = self.mollusk.process_instruction(instruction, accounts);
                 match result.program_result {
                     ProgramResult::Success => (),
@@ -131,11 +133,69 @@ impl<'a> MolluskComputeUnitBencher<'a> {
                         }
                     }
                 }
-                MolluskComputeUnitBenchResult::new(name, result)
+                let cpi_cus = logger.zip(log_idx).map(|(logger, log_idx)| {
+                    calculate_cpi_cus(
+                        logger
+                            .borrow()
+                            .messages
+                            .iter()
+                            .skip(log_idx)
+                            .filter_map(parse_log)
+                            .collect(),
+                    )
+                });
+
+                MolluskComputeUnitBenchResult::new(name, result, cpi_cus)
             })
             .collect::<Vec<_>>();
         write_results(&self.out_dir, &table_header, &solana_version, bench_results);
     }
+}
+
+pub enum LogFrame {
+    Opened { pubkey: Pubkey },
+    Closed { pubkey: Pubkey, consumed: u64 },
+}
+pub fn parse_log(log: impl AsRef<str>) -> Option<LogFrame> {
+    let mut tokens = log.as_ref().split_whitespace();
+
+    let program_id = tokens
+        .next()
+        .filter(|token| *token == "Program")
+        .and_then(|_| tokens.next().map(Pubkey::from_str)?.ok())?;
+
+    match tokens.next() {
+        Some("invoke") => Some(LogFrame::Opened { pubkey: program_id }),
+        Some("consumed") => {
+            let consumed = tokens.next().and_then(|token| u64::from_str(token).ok())?;
+            Some(LogFrame::Closed {
+                pubkey: program_id,
+                consumed,
+            })
+        }
+        _ => None,
+    }
+}
+
+pub fn calculate_cpi_cus(logs: Vec<LogFrame>) -> u64 {
+    let mut depth = 0;
+    let mut cpi_cus = 0;
+
+    for log in logs {
+        match log {
+            LogFrame::Opened { .. } => {
+                depth += 1;
+            }
+            LogFrame::Closed { consumed, .. } => {
+                depth -= 1;
+                if depth == 1 {
+                    cpi_cus += consumed;
+                }
+            }
+        }
+    }
+
+    cpi_cus
 }
 
 pub fn get_solana_version() -> String {

--- a/bencher/src/result.rs
+++ b/bencher/src/result.rs
@@ -9,12 +9,17 @@ use {
 pub struct MolluskComputeUnitBenchResult<'a> {
     name: &'a str,
     cus_consumed: u64,
+    cpi_cus_consumed: Option<u64>,
 }
 
 impl<'a> MolluskComputeUnitBenchResult<'a> {
-    pub fn new(name: &'a str, result: InstructionResult) -> Self {
+    pub fn new(name: &'a str, result: InstructionResult, cpi_cus_consumed: Option<u64>) -> Self {
         let cus_consumed = result.compute_units_consumed;
-        Self { name, cus_consumed }
+        Self {
+            name,
+            cus_consumed,
+            cpi_cus_consumed,
+        }
     }
 }
 
@@ -105,7 +110,11 @@ fn parse_last_md_table(content: &str) -> Vec<MolluskComputeUnitBenchResult> {
         let name = parts.next().unwrap();
         let cus_consumed = parts.next().unwrap().parse().unwrap();
 
-        results.push(MolluskComputeUnitBenchResult { name, cus_consumed });
+        results.push(MolluskComputeUnitBenchResult {
+            name,
+            cus_consumed,
+            cpi_cus_consumed: None,
+        });
     }
 
     results

--- a/bencher/src/result.rs
+++ b/bencher/src/result.rs
@@ -7,18 +7,18 @@ use {
 };
 
 pub struct MolluskComputeUnitBenchResult<'a> {
-    name: &'a str,
-    cus_consumed: u64,
-    cpi_cus_consumed: Option<u64>,
+    pub name: &'a str,
+    pub cus_consumed: u64,
+    pub logs: Option<Vec<String>>,
 }
 
 impl<'a> MolluskComputeUnitBenchResult<'a> {
-    pub fn new(name: &'a str, result: InstructionResult, cpi_cus_consumed: Option<u64>) -> Self {
+    pub fn new(name: &'a str, result: InstructionResult, logs: Option<Vec<String>>) -> Self {
         let cus_consumed = result.compute_units_consumed;
         Self {
             name,
             cus_consumed,
-            cpi_cus_consumed,
+            logs,
         }
     }
 }
@@ -113,7 +113,7 @@ fn parse_last_md_table(content: &str) -> Vec<MolluskComputeUnitBenchResult> {
         results.push(MolluskComputeUnitBenchResult {
             name,
             cus_consumed,
-            cpi_cus_consumed: None,
+            logs: None,
         });
     }
 

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -169,6 +169,7 @@ impl Runner {
             Some(MolluskComputeUnitBenchResult::new(
                 parse_fixture_name(fixture_path),
                 target_result.clone(),
+                None,
             ))
         } else {
             None


### PR DESCRIPTION
## Problem 
Currenly the `MolluskComputeUnitBencher` doesn't allow run the bench without writing the file and returning the results. 

## Solution
- add `execute_without_write` which only runs the bench and returns the bench results
- make the `MolluskComputeUnitBenchResult` public as well as it fields 

## Notes
- #104  