### PR TITLE
docs: add default paths to Mollusk::new

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -464,6 +464,15 @@ impl Mollusk {
     /// Attempts the load the program's ELF file from the default search paths.
     /// Once loaded, adds the program to the program cache and returns the
     /// newly created Mollusk instance.
+    ///
+    /// # Default Search Paths
+    ///
+    /// The following locations are checked in order:
+    /// 
+    /// - `tests/fixtures`
+    /// - The directory specified by the `BPF_OUT_DIR` environment variable
+    /// - The directory specified by the `SBF_OUT_DIR` environment variable
+    /// - The current working directory
     pub fn new(program_id: &Pubkey, program_name: &str) -> Self {
         let mut mollusk = Self::default();
         mollusk.add_program(program_id, program_name, &DEFAULT_LOADER_KEY);

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -468,7 +468,7 @@ impl Mollusk {
     /// # Default Search Paths
     ///
     /// The following locations are checked in order:
-    /// 
+    ///
     /// - `tests/fixtures`
     /// - The directory specified by the `BPF_OUT_DIR` environment variable
     /// - The directory specified by the `SBF_OUT_DIR` environment variable


### PR DESCRIPTION
I know the the default paths are located at the top of file.rs but when a dev has an issue with `Mollusk::new` It takes them a minute to track the `load_program` func and since the comments for `Mollusk::new` references the "default path" it should be highlighted