### PR TITLE
fix: use correct license name in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 authors = ["Anza Technology Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/mollusk"
 readme = "README.md"
-license = "Apache-2.0"
+license-file = "LICENSE"
 edition = "2021"
 version = "0.1.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 authors = ["Anza Technology Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/anza-xyz/mollusk"
 readme = "README.md"
-license = "MIT"
+license = "Apache-2.0"
 edition = "2021"
 version = "0.1.5"
 

--- a/bencher/Cargo.toml
+++ b/bencher/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://docs.rs/mollusk-svm-bencher"
 authors = { workspace = true }
 repository = { workspace = true }
 readme = { workspace = true }
-license = { workspace = true }
+license-file ={ workspace = true }
 edition = { workspace = true }
 version = { workspace = true }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,7 @@ description = "Mollusk CLI."
 documentation = "https://docs.rs/mollusk-svm-cli"
 authors = { workspace = true }
 repository = { workspace = true }
-license = { workspace = true }
+license-file ={ workspace = true }
 edition = { workspace = true }
 version = { workspace = true }
 

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://docs.rs/mollusk-svm-error"
 authors = { workspace = true }
 repository = { workspace = true }
 readme = { workspace = true }
-license = { workspace = true }
+license-file ={ workspace = true }
 edition = { workspace = true }
 version = { workspace = true }
 

--- a/fuzz/fixture-fd/Cargo.toml
+++ b/fuzz/fixture-fd/Cargo.toml
@@ -4,7 +4,7 @@ description = "Mollusk-compatible Firedancer fuzz fixture for SVM programs."
 documentation = "https://docs.rs/mollusk-svm-fuzz-fixture-firedancer"
 authors = { workspace = true }
 repository = { workspace = true }
-license = { workspace = true }
+license-file ={ workspace = true }
 edition = { workspace = true }
 version = { workspace = true }
 

--- a/fuzz/fixture/Cargo.toml
+++ b/fuzz/fixture/Cargo.toml
@@ -4,7 +4,7 @@ description = "Mollusk-compatible fuzz fixture for SVM programs."
 documentation = "https://docs.rs/mollusk-svm-fuzz-fixture"
 authors = { workspace = true }
 repository = { workspace = true }
-license = { workspace = true }
+license-file ={ workspace = true }
 edition = { workspace = true }
 version = { workspace = true }
 

--- a/fuzz/fs/Cargo.toml
+++ b/fuzz/fs/Cargo.toml
@@ -4,7 +4,7 @@ description = "Filesystem management for fuzz tooling."
 documentation = "https://docs.rs/mollusk-svm-fuzz-fs"
 authors = { workspace = true }
 repository = { workspace = true }
-license = { workspace = true }
+license-file ={ workspace = true }
 edition = { workspace = true }
 version = { workspace = true }
 

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://docs.rs/mollusk-svm"
 authors = { workspace = true }
 repository = { workspace = true }
 readme = { workspace = true }
-license = { workspace = true }
+license-file ={ workspace = true }
 edition = { workspace = true }
 version = { workspace = true }
 

--- a/keys/Cargo.toml
+++ b/keys/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://docs.rs/mollusk-svm-keys"
 authors = { workspace = true }
 repository = { workspace = true }
 readme = { workspace = true }
-license = { workspace = true }
+license-file ={ workspace = true }
 edition = { workspace = true }
 version = { workspace = true }
 

--- a/programs/memo/Cargo.toml
+++ b/programs/memo/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://docs.rs/mollusk-svm-programs-memo"
 authors = { workspace = true }
 repository = { workspace = true }
 readme = { workspace = true }
-license = { workspace = true }
+license-file ={ workspace = true }
 edition = { workspace = true }
 version = { workspace = true }
 

--- a/programs/token/Cargo.toml
+++ b/programs/token/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://docs.rs/mollusk-svm-programs-token"
 authors = { workspace = true }
 repository = { workspace = true }
 readme = { workspace = true }
-license = { workspace = true }
+license-file ={ workspace = true }
 edition = { workspace = true }
 version = { workspace = true }
 


### PR DESCRIPTION
### Problem
`LICENSE` file in the root is **Apache-2.0**, however packages are published to the `crates.io` under the **MIT**

### Solution
use proper license name in the root `Cargo.toml`