### PR TITLE
harness: add rent-exemption account check

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -393,7 +393,7 @@ use {
     agave_feature_set::FeatureSet,
     agave_precompiles::get_precompile,
     mollusk_svm_error::error::{MolluskError, MolluskPanic},
-    result::Config,
+    result::{Config, DefaultCheckContext},
     solana_account::Account,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_fee_structure::FeeStructure,
@@ -682,7 +682,13 @@ impl Mollusk {
         #[cfg(any(feature = "fuzz", feature = "fuzz-fd"))]
         fuzz::generate_fixtures_from_mollusk_test(self, instruction, accounts, &result);
 
-        result.run_checks_with_config(checks, &self.config);
+        result.run_checks_with_context(
+            checks,
+            &DefaultCheckContext {
+                config: &self.config,
+                rent: &self.sysvars.rent,
+            },
+        );
         result
     }
 

--- a/harness/src/result.rs
+++ b/harness/src/result.rs
@@ -266,12 +266,20 @@ impl InstructionResult {
     }
 
     /// Perform checks on the instruction result.
+    ///
+    /// Note: Uses `Rent::default()`. If you wish to provide a custom `Rent`
+    /// instance, or the `Rent` instance on your `Mollusk` instance, use
+    /// `run_checks_with_context`.
     pub fn run_checks_with_config(&self, checks: &[Check], config: &Config) -> bool {
         let rent = &Rent::default();
         self.run_checks_with_context(checks, &DefaultCheckContext { config, rent })
     }
 
     /// Perform checks on the instruction result, panicking on any mismatches.
+    ///
+    /// Note: Uses `Rent::default()`. If you wish to provide a custom `Rent`
+    /// instance, or the `Rent` instance on your `Mollusk` instance, use
+    /// `run_checks_with_context`.
     pub fn run_checks(&self, checks: &[Check]) {
         self.run_checks_with_config(
             checks,

--- a/harness/src/result.rs
+++ b/harness/src/result.rs
@@ -5,6 +5,7 @@ use {
     solana_instruction::error::InstructionError,
     solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
+    solana_rent::Rent,
 };
 
 macro_rules! compare {
@@ -122,6 +123,33 @@ impl Default for Config {
     }
 }
 
+/// A trait for providing context to the checks.
+///
+/// Developers who run checks on standalone results, rather than passing checks
+/// directly to methods like `Mollusk::process_and_validate_instruction`, may
+/// wish to customize the context in which the checks are run. For example,
+/// one may wish to evaluate resulting account lamports with a custom Rent
+/// configuration. This trait allows such customization.
+pub trait CheckContext {
+    fn config(&self) -> &Config;
+    fn rent(&self) -> &Rent;
+}
+
+pub(crate) struct DefaultCheckContext<'a> {
+    pub config: &'a Config,
+    pub rent: &'a Rent,
+}
+
+impl CheckContext for DefaultCheckContext<'_> {
+    fn config(&self) -> &Config {
+        self.config
+    }
+
+    fn rent(&self) -> &Rent {
+        self.rent
+    }
+}
+
 impl InstructionResult {
     /// Get an account from the resulting accounts by its pubkey.
     pub fn get_account(&self, pubkey: &Pubkey) -> Option<&Account> {
@@ -131,9 +159,10 @@ impl InstructionResult {
             .map(|(_, a)| a)
     }
 
-    /// Perform checks on the instruction result.
-    pub fn run_checks_with_config(&self, checks: &[Check], config: &Config) -> bool {
-        let c = config;
+    /// Perform checks on the instruction result, but with a custom context.
+    /// See `CheckContext` for more details.
+    pub fn run_checks_with_context<C: CheckContext>(&self, checks: &[Check], context: &C) -> bool {
+        let c = context.config();
         let mut pass = true;
         for check in checks {
             match &check.check {
@@ -199,6 +228,17 @@ impl InstructionResult {
                                     resulting_account == &Account::default(),
                                 );
                             }
+                            AccountStateCheck::RentExempt => {
+                                pass &= compare!(
+                                    c,
+                                    "account_rent_exempt",
+                                    true,
+                                    context.rent().is_exempt(
+                                        resulting_account.lamports,
+                                        resulting_account.data.len()
+                                    ),
+                                );
+                            }
                         }
                     }
                     if let Some((offset, check_data_slice)) = account.check_data_slice {
@@ -223,6 +263,12 @@ impl InstructionResult {
             }
         }
         pass
+    }
+
+    /// Perform checks on the instruction result.
+    pub fn run_checks_with_config(&self, checks: &[Check], config: &Config) -> bool {
+        let rent = &Rent::default();
+        self.run_checks_with_context(checks, &DefaultCheckContext { config, rent })
     }
 
     /// Perform checks on the instruction result, panicking on any mismatches.
@@ -484,6 +530,7 @@ impl<'a> Check<'a> {
 
 enum AccountStateCheck {
     Closed,
+    RentExempt,
 }
 
 struct AccountCheck<'a> {
@@ -545,6 +592,11 @@ impl<'a> AccountCheckBuilder<'a> {
 
     pub fn owner(mut self, owner: &'a Pubkey) -> Self {
         self.check.check_owner = Some(owner);
+        self
+    }
+
+    pub fn rent_exempt(mut self) -> Self {
+        self.check.check_state = Some(AccountStateCheck::RentExempt);
         self
     }
 

--- a/harness/tests/bpf_program.rs
+++ b/harness/tests/bpf_program.rs
@@ -1,13 +1,14 @@
 use {
     mollusk_svm::{
         program::{create_program_account_loader_v3, keyed_account_for_system_program},
-        result::Check,
+        result::{Check, CheckContext, Config},
         Mollusk,
     },
     solana_account::Account,
     solana_instruction::{error::InstructionError, AccountMeta, Instruction},
     solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
+    solana_rent::Rent,
     solana_system_interface::error::SystemError,
 };
 
@@ -400,4 +401,67 @@ fn test_account_dedupe() {
             &[Check::success()],
         );
     }
+}
+
+#[test]
+fn test_account_checks_rent_exemption() {
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+
+    let program_id = Pubkey::new_unique();
+
+    let mut mollusk = Mollusk::new(&program_id, "test_program_primary");
+    mollusk.config.panic = false; // Don't panic, so we can evaluate failing checks.
+
+    let key = Pubkey::new_unique();
+
+    let data_len = 8;
+    let data = vec![4; data_len];
+
+    let rent_exempt_lamports = mollusk.sysvars.rent.minimum_balance(data_len);
+    let not_rent_exempt_lamports = rent_exempt_lamports - 1;
+
+    struct TestCheckContext<'a> {
+        rent: &'a Rent,
+        config: &'a Config,
+    }
+
+    impl CheckContext for TestCheckContext<'_> {
+        fn rent(&self) -> &Rent {
+            self.rent
+        }
+
+        fn config(&self) -> &Config {
+            self.config
+        }
+    }
+
+    let get_result = |lamports: u64| {
+        mollusk
+            .process_and_validate_instruction(
+                &Instruction::new_with_bytes(
+                    program_id,
+                    &{
+                        let mut instruction_data = vec![1]; // `WriteData`
+                        instruction_data.extend_from_slice(&data);
+                        instruction_data
+                    },
+                    vec![AccountMeta::new(key, true)],
+                ),
+                &[(key, Account::new(lamports, data_len, &program_id))],
+                &[Check::success()], // It should still pass.
+            )
+            .run_checks_with_context(
+                &[Check::account(&key).rent_exempt().build()],
+                &TestCheckContext {
+                    rent: &mollusk.sysvars.rent,
+                    config: &mollusk.config,
+                },
+            )
+    };
+
+    // Fail not rent exempt.
+    assert!(!get_result(not_rent_exempt_lamports));
+
+    // Success rent exempt.
+    assert!(get_result(rent_exempt_lamports));
 }


### PR DESCRIPTION
Adds a new account check to assert a resulting account is rent-exempt.

```rust
Check::account(&key)
    .rent_exempt() // <--
    .build()
```

When the check is provided to `Mollusk::process_and_validate_instruction`, it uses the Rent instance located at `mollusk.sysvars.rent`. However, this check can also be provided to functions like `InstructionResult::run_checks`.

Unfortunately, in order to avoid a breaking change, I had to introduce a new method `InstructionResult::run_checks_with_context` which allows the Rent instance to be provided via trait implementation. the trait approach gives us much more flexibility in the future if we need to add more context items. However, the drawback is that both `InstructionResult::run_checks` and `InstructionResult::run_checks_with_config` will always use the default Rent instance (ie. `Rent::default()`).

I added documentation to reflect this potential footgun. The alternative is to make this a breaking change, and simply replace `run_checks` with this new trait-based approach, and drop the others.

Since you requested this feature @jstarry, let me know if you have thoughts.

The breaking-change alternative is here: https://github.com/anza-xyz/mollusk/pull/112