### PR TITLE
harness: add rent-exemption account check

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -387,7 +387,7 @@ use {
     crate::{
         compile_accounts::CompiledAccounts,
         program::ProgramCache,
-        result::{Check, Config, InstructionResult},
+        result::{Check, CheckContext, Config, InstructionResult},
         sysvar::Sysvars,
     },
     agave_feature_set::FeatureSet,
@@ -454,6 +454,12 @@ impl Default for Mollusk {
             #[cfg(feature = "fuzz-fd")]
             slot: 0,
         }
+    }
+}
+
+impl CheckContext for Mollusk {
+    fn is_rent_exempt(&self, lamports: u64, space: usize) -> bool {
+        self.sysvars.rent.is_exempt(lamports, space)
     }
 }
 
@@ -681,7 +687,7 @@ impl Mollusk {
         #[cfg(any(feature = "fuzz", feature = "fuzz-fd"))]
         fuzz::generate_fixtures_from_mollusk_test(self, instruction, accounts, &result);
 
-        result.run_checks_with_config(checks, &self.config);
+        result.run_checks(checks, &self.config, self);
         result
     }
 


### PR DESCRIPTION
Adds a new account check to assert a resulting account is rent-exempt.

```rust
Check::account(&key)
    .rent_exempt() // <--
    .build()
```

When the check is provided to `Mollusk::process_and_validate_instruction`, it uses the Rent instance located at `mollusk.sysvars.rent`. However, this check can also be provided to functions like `InstructionResult::run_checks`.

Note that this is a breaking change. It updates `InstructionResult::run_checks` to accept a `CheckContext` trait implementation, which can offer certain methods such as `is_rent_exempt` for use in checks. I felt like it was best to make this breaking and remove any other "run checks" methods, to make it very clear that you will need to provide a way to check rent exemption (and likely other checks in the future) if you don't pass the checks directly to `Mollusk::process_and_validate_instruction`.

Note: `Mollusk` implements `CheckContext`, so you can just pass a `Mollusk` instance if you have no need for custom configurations.