### PR TITLE
fix: make BPF Loader v3 program data executable

### DIFF
--- a/harness/src/program.rs
+++ b/harness/src/program.rs
@@ -244,7 +244,7 @@ pub fn create_program_data_account_loader_v3(elf: &[u8]) -> Account {
         lamports,
         data,
         owner: loader_keys::LOADER_V3,
-        executable: false,
+        executable: true,
         ..Default::default()
     }
 }


### PR DESCRIPTION
### Problem

testing instructions that use accounts of programs (BPF Loader v3) fails with error

```bash
Anchor Error caused by account:<your account here>. Error Code: Invalid Program Executable. Error Number: 3009. Error Message: Program account is not executable
```

example: Meteora Pools Swap
https://solscan.io/tx/5vk5VoEQX9VsAkVyCuVP81Az1jnrfUGp731Z539vAkge6VALmJckwGMU93WB8rFFUHLHrTpmmLmHxuhnGFXNBM3V

it uses `24Uqj9JCLxUeoC3hGfh5W3s9FM9uCHDS2SG3LYwBpyTi `as Vault Program.

that loads to the mollusk as not executable

### Solution

change the `create_program_data_account_loader_v3` and set `executable = true` to pass itmore correctly

### Alternative

change  definition of `create_program_data_account_loader_v3` like follows:

```diff
-pub fn create_program_data_account_loader_v3(elf: &[u8]) -> Account {

+pub fn create_program_data_account_loader_v3(elf: &[u8], executable: bool) -> Account {
```