### PR TITLE
chore: add `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.86.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.84.1"


### PR DESCRIPTION
### Problem
right now there is no way to auto provide `rustup` toolchains and their  associated pieces. to install, remove, update, etc

### Potential Solution
use `rust-toolchain.toml` and pin channel to `1.86.0`