### PR TITLE
feat: account fetchers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "ark-bn254"
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -314,6 +314,12 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atty"
@@ -370,15 +376,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "blake3"
-version = "1.5.5"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -548,9 +554,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cast"
@@ -581,16 +587,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -704,6 +710,16 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -922,6 +938,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "eager"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +982,15 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-iterator"
@@ -997,12 +1033,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1095,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1126,9 +1162,9 @@ checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1235,6 +1271,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
+name = "h2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1322,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -1376,9 +1437,9 @@ checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -1389,6 +1450,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1417,6 +1479,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,9 +1513,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1464,23 +1544,120 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "icu_collections"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -1643,9 +1820,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -1692,6 +1875,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1767,6 +1956,46 @@ dependencies = [
  "solana-sysvar-id",
  "solana-timings",
  "solana-transaction-context",
+]
+
+[[package]]
+name = "mollusk-svm-account-fetcher-fs"
+version = "0.3.0"
+dependencies = [
+ "base64 0.22.1",
+ "mollusk-svm-account-fetcher-serde",
+ "serde_json",
+ "solana-account",
+ "solana-pubkey",
+ "tempfile",
+ "thiserror 1.0.68",
+]
+
+[[package]]
+name = "mollusk-svm-account-fetcher-rpc"
+version = "0.3.0"
+dependencies = [
+ "base64 0.22.1",
+ "mollusk-svm-account-fetcher-serde",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "solana-account",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "thiserror 1.0.68",
+ "tokio",
+]
+
+[[package]]
+name = "mollusk-svm-account-fetcher-serde"
+version = "0.3.0"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+ "solana-account",
+ "solana-pubkey",
 ]
 
 [[package]]
@@ -1909,6 +2138,23 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "num"
@@ -2071,6 +2317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "openssl-src"
 version = "300.4.2+3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2451,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2502,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2514,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2525,9 +2786,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -2538,17 +2799,22 @@ dependencies = [
  "async-compression",
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2559,6 +2825,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -2609,15 +2876,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2677,16 +2944,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.23"
+name = "security-framework"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -2699,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.15"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
 dependencies = [
  "serde",
 ]
@@ -2719,9 +3018,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -2794,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2855,9 +3154,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -3509,9 +3808,9 @@ dependencies = [
 
 [[package]]
 name = "solana-native-token"
-version = "2.3.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61515b880c36974053dd499c0510066783f0cc6ac17def0c7ef2a244874cf4a9"
+checksum = "307fb2f78060995979e9b4f68f833623565ed4e55d3725f100454ce78a99a1a3"
 
 [[package]]
 name = "solana-nonce"
@@ -3886,14 +4185,14 @@ checksum = "36187af2324f079f65a675ec22b31c24919cb4ac22c79472e85d819db9bbbc15"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "solana-serde-varint"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc07d00200d82e6def2f7f7a45738e3406b17fe54a18adcf0defa16a97ccadb"
+checksum = "2a7e155eba458ecfb0107b98236088c3764a09ddf0201ec29e52a0be40857113"
 dependencies = [
  "serde",
 ]
@@ -3915,7 +4214,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0037386961c0d633421f53560ad7c80675c0447cba4d1bb66d60974dd486c7ea"
 dependencies = [
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "solana-define-syscall",
  "solana-hash",
 ]
@@ -3942,12 +4241,12 @@ dependencies = [
 
 [[package]]
 name = "solana-signature"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d251c8f3dc015f320b4161daac7f108156c837428e5a8cc61136d25beb11d6"
+checksum = "64c8ec8e657aecfc187522fc67495142c12f35e55ddeca8698edbb738b8dbd8c"
 dependencies = [
- "bs58",
  "ed25519-dalek",
+ "five8",
  "solana-sanitize",
 ]
 
@@ -4239,6 +4538,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4282,13 +4587,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.13.0"
+name = "synstructure"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
- "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
  "fastrand",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -4368,6 +4705,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4394,9 +4741,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4412,13 +4759,23 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -4433,9 +4790,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4547,25 +4904,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -4596,14 +4938,20 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -4820,6 +5168,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-registry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1da3e436dc7653dfdf3da67332e22bff09bb0e28b0239e1624499c7830842e"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4920,6 +5303,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4941,6 +5354,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4954,6 +5388,39 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "bencher",
     "cli",
     "error",
+    "fetcher/*",
     "fuzz/*",
     "harness",
     "keys",
@@ -23,6 +24,7 @@ version = "0.3.0"
 [workspace.dependencies]
 agave-feature-set = "2.3"
 agave-precompiles = "2.3"
+base64 = "0.22.1"
 bincode = "1.3.3"
 bs58 = "0.5.1"
 chrono = "0.4.38"
@@ -31,6 +33,9 @@ criterion = "0.5.1"
 ed25519-dalek = "=1.0.1"
 libsecp256k1 = "0.6.0"
 mollusk-svm = { path = "harness", version = "0.3.0" }
+mollusk-svm-account-fetcher-fs = { path = "fetcher/fs", version = "0.3.0" }
+mollusk-svm-account-fetcher-rpc = { path = "fetcher/rpc", version = "0.3.0" }
+mollusk-svm-account-fetcher-serde = { path = "fetcher/serde", version = "0.3.0" }
 mollusk-svm-bencher = { path = "bencher", version = "0.3.0" }
 mollusk-svm-cli = { path = "cli", version = "0.3.0" }
 mollusk-svm-error = { path = "error", version = "0.3.0" }
@@ -48,6 +53,7 @@ prost-build = "0.9"
 prost-types = "0.9"
 rand0-7 = { package = "rand", version = "0.7" }
 rayon = "1.10.0"
+reqwest = "0.12.20"
 serde = "1.0.203"
 serde_json = "1.0.117"
 serde_yaml = "0.9.34"
@@ -88,6 +94,7 @@ solana-sysvar = "2.2"
 solana-sysvar-id = "2.2"
 solana-timings = "2.3"
 solana-transaction-context = "2.3"
+tempfile = "3.13.0"
 thiserror = "1.0.64"
 tokio = "1.37.0"
 which = "=4.4.0"

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ prepublish:
 publish:
 	@set -e && set -u && set -o pipefail && \
 	CRATES=( \
+		"mollusk-svm-account-fetcher-serde" \
+		"mollusk-svm-account-fetcher-fs" \
+		"mollusk-svm-account-fetcher-rpc" \
 		"mollusk-svm-error" \
 		"mollusk-svm-keys" \
 		"mollusk-svm-fuzz-fs" \

--- a/fetcher/README.md
+++ b/fetcher/README.md
@@ -1,0 +1,135 @@
+# Mollusk Account Fetchers
+
+Simple, lightweight account fetching utilities for Mollusk.
+
+## Overview
+
+Two standalone account fetchers that can be used with or without Mollusk:
+
+* **`mollusk-svm-account-fetcher-fs`** - Load accounts from local JSON files
+* **`mollusk-svm-account-fetcher-rpc`** - Fetch accounts via Solana JSON-RPC
+
+Both fetchers are designed to be minimal and composable, returning standard
+`Vec<(Pubkey, Account)>` that can be used directly with Mollusk's instruction
+processing methods.
+
+## File System Fetcher
+
+The file system fetcher loads accounts from JSON files that match the format
+produced by `solana account -o json`.
+
+You can dump accounts to JSON files using the Solana JSON-RPC:
+
+```bash
+solana account <ADDRESS> --output json --output-file account.json
+```
+
+```rust
+use mollusk_svm_account_fetcher_fs::{
+  load_account_from_json_file,
+  load_multiple_accounts_from_directory,
+  load_multiple_accounts_from_json_file,
+};
+
+// Load a single account from a file.
+let (pubkey, account) = load_account_from_json_file("./account.json")?;
+
+// Load multiple accounts from an array in a file.
+let accounts = load_multiple_accounts_from_json_file("./accounts.json")?;
+
+// Recursively load all JSON files from a directory.
+let accounts = load_multiple_accounts_from_directory("./fixtures")?;
+```
+
+Each account JSON should match the exact format produced by the Solana CLI:
+
+```json
+{
+  "pubkey": "DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh",
+  "account": {
+    "lamports": 1000000000,
+    "data": ["SGVsbG8gV29ybGQh", "base64"],
+    "owner": "11111111111111111111111111111111",
+    "executable": false,
+    "rentEpoch": 0,
+    "space": 13
+  }
+}
+```
+
+An array of accounts can be stored in a single file:
+
+```json
+[
+  {
+    "pubkey": "DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh",
+    "account": {
+      "lamports": 1000000000,
+      "data": ["SGVsbG8gV29ybGQh", "base64"],
+      "owner": "11111111111111111111111111111111",
+      "executable": false,
+      "rentEpoch": 0,
+      "space": 13
+    }
+  },
+  {
+    "pubkey": "EkBn7qWtupWhZvCXYAKcvkLEKqMWPHdcV84QdE9MLLan",
+    "account": {
+      "lamports": 2000000000,
+      "data": ["AQIDBAUGBwg=", "base64"],
+      "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+      "executable": false,
+      "rentEpoch": 0,
+      "space": 8
+    }
+  }
+]
+```
+
+## RPC Fetcher
+
+The RPC fetcher provides a minimal client for fetching accounts from Solana
+JSON-RPC endpoints without the overhead of `solana-client`. It reimplements
+only the `getAccountInfo` and `getMultipleAccounts` methods using `reqwest`.
+
+The RPC fetcher imposes the following default RPC behavior:
+* Always requests accounts with `base64` encoding
+* Automatically decodes the base64 data into `Vec<u8>` for the `Account` struct
+* Returns `None` for accounts that don't exist on-chain
+
+```rust
+use mollusk_svm_account_fetcher_rpc::{
+    fetch_account, 
+    fetch_accounts,
+    fetch_accounts_with_default
+};
+
+// Fetch a single account (returns `Option<Account>`).
+let account = fetch_account(
+    "https://api.mainnet-beta.solana.com", 
+    &pubkey
+).await?;
+
+// Fetch multiple accounts (returns `Vec<(Pubkey, Account)>`).
+// Always returns one account per pubkey, using `Account::default()` for
+// non-existent ones.
+let accounts = fetch_accounts(
+    "https://api.mainnet-beta.solana.com",
+    &[pubkey1, pubkey2, pubkey3]
+).await?;
+
+// Fetch with custom defaults for missing accounts.
+// Allows you to specify how default accounts should be created.
+let accounts = fetch_accounts_with_default(
+    "https://api.mainnet-beta.solana.com",
+    &[pubkey1, pubkey2, pubkey3],
+    |_pubkey| Account::default()  // <-- Your custom default logic
+).await?;
+```
+
+These functions create a new `RpcClient` internally for each call. If you're
+making multiple requests, consider using the `RpcClient` directly.
+
+```rust
+let client = RpcClient::new("https://api.mainnet-beta.solana.com");
+```

--- a/fetcher/fs/Cargo.toml
+++ b/fetcher/fs/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mollusk-svm-account-fetcher-fs"
+description = "File system account fetcher for Mollusk SVM"
+documentation = "https://docs.rs/mollusk-svm-account-fetcher-fs"
+authors = { workspace = true }
+repository = { workspace = true }
+readme = { workspace = true }
+license-file ={ workspace = true }
+edition = { workspace = true }
+version = { workspace = true }
+
+[dependencies]
+base64 = { workspace = true }
+mollusk-svm-account-fetcher-serde = { workspace = true }
+serde_json = { workspace = true }
+solana-account = { workspace = true }
+solana-pubkey = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/fetcher/fs/src/lib.rs
+++ b/fetcher/fs/src/lib.rs
@@ -1,0 +1,253 @@
+//! File system account fetcher.
+//!
+//! This crate provides utilities to load Solana accounts from JSON files
+//! that match the format produced by `solana account -o json`.
+
+use {
+    mollusk_svm_account_fetcher_serde::KeyedUiAccount,
+    solana_account::Account,
+    solana_pubkey::Pubkey,
+    std::{fs, path::Path},
+    thiserror::Error,
+};
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Base64 decode error: {0}")]
+    Base64(#[from] base64::DecodeError),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON deserialization error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+/// Load a single account from a JSON file.
+///
+/// The file should contain a single account object in the same format
+/// as produced by `solana account -o json`.
+pub fn load_account_from_json_file<P: AsRef<Path>>(path: P) -> Result<(Pubkey, Account), Error> {
+    let content = fs::read_to_string(path)?;
+    let keyed_account: KeyedUiAccount = serde_json::from_str(&content)?;
+    Ok(keyed_account.try_into()?)
+}
+
+/// Load multiple accounts from a JSON file containing an array.
+///
+/// The file should contain an array of account objects, each in the same format
+/// as produced by `solana account -o json`.
+pub fn load_multiple_accounts_from_json_file<P: AsRef<Path>>(
+    path: P,
+) -> Result<Vec<(Pubkey, Account)>, Error> {
+    let content = fs::read_to_string(path)?;
+    let keyed_accounts: Vec<KeyedUiAccount> = serde_json::from_str(&content)?;
+    keyed_accounts
+        .into_iter()
+        .map(TryInto::try_into)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+/// Load accounts from multiple files in a directory.
+///
+/// This function will recursively search for `.json` files in the given
+/// directory and attempt to load accounts from each file. Non-JSON files are
+/// skipped. If a JSON file fails to parse, the operation will fail with an
+/// error.
+pub fn load_multiple_accounts_from_directory<P: AsRef<Path>>(
+    dir: P,
+) -> Result<Vec<(Pubkey, Account)>, Error> {
+    let mut all_accounts = Vec::new();
+    let dir = dir.as_ref();
+
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            // Recursively load from any subdirectories.
+            let sub_accounts = load_multiple_accounts_from_directory(&path)?;
+            all_accounts.extend(sub_accounts);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("json") {
+            // Try to load as an array first, then try as a single account.
+            match load_multiple_accounts_from_json_file(&path) {
+                Ok(accounts) => all_accounts.extend(accounts),
+                Err(_) => {
+                    let account = load_account_from_json_file(&path)?;
+                    all_accounts.push(account);
+                }
+            }
+        }
+    }
+
+    Ok(all_accounts)
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, base64::Engine, std::io::Write, tempfile::TempDir};
+
+    #[test]
+    fn test_load_single_account() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("account.json");
+
+        let pubkey = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let lamports = 1234567890;
+        let rent_epoch = 42;
+        let data = vec![1, 2, 3, 4, 5];
+        let data_base64 = base64::engine::general_purpose::STANDARD.encode(&data);
+        let space = data.len();
+
+        let json_content = format!(
+            r#"{{
+            "pubkey": "{pubkey}",
+            "account": {{
+                "lamports": {lamports},
+                "data": ["{data_base64}", "base64"],
+                "owner": "{owner}",
+                "executable": true,
+                "rentEpoch": {rent_epoch},
+                "space": {space}
+            }}
+        }}"#
+        );
+
+        let mut file = fs::File::create(&file_path).unwrap();
+        file.write_all(json_content.as_bytes()).unwrap();
+
+        let (loaded_pubkey, account) = load_account_from_json_file(&file_path).unwrap();
+        assert_eq!(loaded_pubkey, pubkey);
+        assert_eq!(account.lamports, lamports);
+        assert_eq!(account.data, data);
+        assert_eq!(account.owner, owner);
+        assert!(account.executable);
+        assert_eq!(account.rent_epoch, rent_epoch);
+    }
+
+    #[test]
+    fn test_load_multiple_accounts() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("accounts.json");
+
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+        let owner1 = Pubkey::new_unique();
+        let owner2 = Pubkey::new_unique();
+        let lamports1 = 1000000;
+        let lamports2 = 2000000;
+        let rent_epoch1 = 100;
+        let rent_epoch2 = 200;
+        let data1: Vec<u8> = vec![];
+        let data2 = vec![1, 2, 3];
+        let data2_base64 = base64::engine::general_purpose::STANDARD.encode(&data2);
+        let space1 = data1.len();
+        let space2 = data2.len();
+
+        let json_content = format!(
+            r#"[
+            {{
+                "pubkey": "{pubkey1}",
+                "account": {{
+                    "lamports": {lamports1},
+                    "data": ["", "base64"],
+                    "owner": "{owner1}",
+                    "executable": false,
+                    "rentEpoch": {rent_epoch1},
+                    "space": {space1}
+                }}
+            }},
+            {{
+                "pubkey": "{pubkey2}",
+                "account": {{
+                    "lamports": {lamports2},
+                    "data": ["{data2_base64}", "base64"],
+                    "owner": "{owner2}",
+                    "executable": true,
+                    "rentEpoch": {rent_epoch2},
+                    "space": {space2}
+                }}
+            }}
+        ]"#
+        );
+
+        let mut file = fs::File::create(&file_path).unwrap();
+        file.write_all(json_content.as_bytes()).unwrap();
+
+        let accounts = load_multiple_accounts_from_json_file(&file_path).unwrap();
+        assert_eq!(accounts.len(), 2);
+
+        assert_eq!(accounts[0].0, pubkey1);
+        assert_eq!(accounts[0].1.lamports, lamports1);
+        assert_eq!(accounts[0].1.data, data1);
+        assert_eq!(accounts[0].1.owner, owner1);
+        assert!(!accounts[0].1.executable);
+        assert_eq!(accounts[0].1.rent_epoch, rent_epoch1);
+
+        assert_eq!(accounts[1].0, pubkey2);
+        assert_eq!(accounts[1].1.lamports, lamports2);
+        assert_eq!(accounts[1].1.data, data2);
+        assert_eq!(accounts[1].1.owner, owner2);
+        assert!(accounts[1].1.executable);
+        assert_eq!(accounts[1].1.rent_epoch, rent_epoch2);
+    }
+
+    #[test]
+    fn test_load_directory_with_invalid_json() {
+        let dir = TempDir::new().unwrap();
+
+        // Create a file with .json extension but invalid contents.
+        let mut file = fs::File::create(dir.path().join("invalid.json")).unwrap();
+        file.write_all(b"{ invalid json }").unwrap();
+
+        let result = load_multiple_accounts_from_directory(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_directory_skip_non_json() {
+        let dir = TempDir::new().unwrap();
+
+        // Create a valid JSON account file.
+        let pubkey = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let lamports = 987654321;
+        let rent_epoch = 555;
+        let data = vec![10, 20, 30];
+        let data_base64 = base64::engine::general_purpose::STANDARD.encode(&data);
+
+        let valid_json = format!(
+            r#"{{
+            "pubkey": "{pubkey}",
+            "account": {{
+                "lamports": {lamports},
+                "data": ["{data_base64}", "base64"],
+                "owner": "{owner}",
+                "executable": false,
+                "rentEpoch": {rent_epoch},
+                "space": {}
+            }}
+        }}"#,
+            data.len()
+        );
+        let mut file = fs::File::create(dir.path().join("account.json")).unwrap();
+        file.write_all(valid_json.as_bytes()).unwrap();
+
+        // Create non-JSON files (should be skipped).
+        fs::File::create(dir.path().join("readme.txt")).unwrap();
+        fs::File::create(dir.path().join("config.toml")).unwrap();
+        fs::File::create(dir.path().join("data.bin")).unwrap();
+
+        // Should only load the one JSON file.
+        let accounts = load_multiple_accounts_from_directory(dir.path()).unwrap();
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0].0, pubkey);
+        assert_eq!(accounts[0].1.lamports, lamports);
+        assert_eq!(accounts[0].1.data, data);
+        assert_eq!(accounts[0].1.owner, owner);
+        assert!(!accounts[0].1.executable);
+        assert_eq!(accounts[0].1.rent_epoch, rent_epoch);
+    }
+}

--- a/fetcher/rpc/Cargo.toml
+++ b/fetcher/rpc/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "mollusk-svm-account-fetcher-rpc"
+description = "JSON-RPC account fetcher for Mollusk SVM"
+documentation = "https://docs.rs/mollusk-svm-account-fetcher-rpc"
+authors = { workspace = true }
+repository = { workspace = true }
+readme = { workspace = true }
+license-file ={ workspace = true }
+edition = { workspace = true }
+version = { workspace = true }
+
+[dependencies]
+base64 = { workspace = true }
+mollusk-svm-account-fetcher-serde = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+solana-account = { workspace = true }
+solana-pubkey = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+solana-sdk-ids = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/fetcher/rpc/src/lib.rs
+++ b/fetcher/rpc/src/lib.rs
@@ -1,0 +1,237 @@
+//! Minimal JSON-RPC account fetcher.
+//!
+//! This crate provides a lightweight RPC client for fetching Solana accounts
+//! without the overhead of the full solana-client library.
+
+use {
+    mollusk_svm_account_fetcher_serde::UiAccount,
+    serde::{Deserialize, Serialize},
+    solana_account::Account,
+    solana_pubkey::Pubkey,
+    thiserror::Error,
+};
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Base64 decode error: {0}")]
+    Base64(#[from] base64::DecodeError),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("HTTP request error: {0}")]
+    Request(#[from] reqwest::Error),
+
+    #[error("RPC error: {code}: {message}")]
+    Rpc { code: i64, message: String },
+}
+
+/// Minimal RPC client for fetching Solana accounts.
+pub struct RpcClient {
+    url: String,
+    client: reqwest::Client,
+}
+
+impl RpcClient {
+    /// Create a new RPC client with the given endpoint URL.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Fetch a single account.
+    pub async fn get_account(&self, pubkey: &Pubkey) -> Result<Option<Account>, Error> {
+        let request = RpcRequest {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "getAccountInfo",
+            params: serde_json::json!([
+                pubkey.to_string(),
+                {
+                    "encoding": "base64",
+                    "commitment": "confirmed"
+                }
+            ]),
+        };
+
+        let response: RpcResponse<RpcAccountInfo> = self.send_request(request).await?;
+
+        match response.result.value {
+            Some(ui_account) => Ok(Some(ui_account.try_into()?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Fetch multiple accounts.
+    pub async fn get_multiple_accounts(
+        &self,
+        pubkeys: &[Pubkey],
+    ) -> Result<Vec<Option<Account>>, Error> {
+        let pubkey_strings: Vec<String> = pubkeys.iter().map(|p| p.to_string()).collect();
+
+        let request = RpcRequest {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "getMultipleAccounts",
+            params: serde_json::json!([
+                pubkey_strings,
+                {
+                    "encoding": "base64",
+                    "commitment": "confirmed"
+                }
+            ]),
+        };
+
+        let response: RpcResponse<RpcMultipleAccounts> = self.send_request(request).await?;
+
+        response
+            .result
+            .value
+            .into_iter()
+            .map(|opt_account| match opt_account {
+                Some(ui_account) => Ok(Some(ui_account.try_into()?)),
+                None => Ok(None),
+            })
+            .collect()
+    }
+
+    async fn send_request<T: for<'de> Deserialize<'de>>(
+        &self,
+        request: RpcRequest,
+    ) -> Result<RpcResponse<T>, Error> {
+        let response = self.client.post(&self.url).json(&request).send().await?;
+
+        let text = response.text().await?;
+        let rpc_response: RpcResponse<T> = serde_json::from_str(&text)?;
+
+        if let Some(error) = rpc_response.error {
+            return Err(Error::Rpc {
+                code: error.code,
+                message: error.message,
+            });
+        }
+
+        Ok(rpc_response)
+    }
+}
+
+#[derive(Serialize)]
+struct RpcRequest {
+    jsonrpc: &'static str,
+    id: u64,
+    method: &'static str,
+    params: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct RpcResponse<T> {
+    #[allow(dead_code)]
+    jsonrpc: String,
+    result: T,
+    error: Option<RpcError>,
+    #[allow(dead_code)]
+    id: u64,
+}
+
+#[derive(Deserialize)]
+struct RpcError {
+    code: i64,
+    message: String,
+}
+
+#[derive(Deserialize)]
+struct RpcAccountInfo {
+    value: Option<UiAccount>,
+}
+
+#[derive(Deserialize)]
+struct RpcMultipleAccounts {
+    value: Vec<Option<UiAccount>>,
+}
+
+/// Fetch a single account from a Solana RPC endpoint.
+pub async fn fetch_account(url: &str, pubkey: &Pubkey) -> Result<Option<Account>, Error> {
+    let client = RpcClient::new(url);
+    client.get_account(pubkey).await
+}
+
+/// Fetch multiple accounts from a Solana RPC endpoint.
+///
+/// Returns exactly one account for each requested pubkey. If an account doesn't
+/// exist on-chain, `Account::default()` is used.
+pub async fn fetch_accounts(
+    url: &str,
+    pubkeys: &[Pubkey],
+) -> Result<Vec<(Pubkey, Account)>, Error> {
+    fetch_accounts_with_default(url, pubkeys, |_| Account::default()).await
+}
+
+/// Fetch multiple accounts from a Solana RPC endpoint with a custom default for
+/// missing accounts.
+///
+/// Returns exactly one account for each requested pubkey. If an account doesn't
+/// exist on-chain, the provided default function is called.
+pub async fn fetch_accounts_with_default<F>(
+    url: &str,
+    pubkeys: &[Pubkey],
+    default_account: F,
+) -> Result<Vec<(Pubkey, Account)>, Error>
+where
+    F: Fn(&Pubkey) -> Account,
+{
+    let client = RpcClient::new(url);
+    let accounts = client.get_multiple_accounts(pubkeys).await?;
+
+    let mut result = Vec::new();
+    for (pubkey, account_opt) in pubkeys.iter().zip(accounts.into_iter()) {
+        let account = account_opt.unwrap_or_else(|| default_account(pubkey));
+        result.push((*pubkey, account));
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_sdk_ids::{system_program::ID as SYSTEM_PROGRAM_ID, vote::ID as VOTE_PROGRAM_ID},
+    };
+
+    #[tokio::test]
+    async fn test_fetch_accounts() {
+        let client = RpcClient::new("https://api.mainnet-beta.solana.com");
+
+        // Fetch the system program (should always exist).
+        match client.get_account(&SYSTEM_PROGRAM_ID).await {
+            Ok(Some(account)) => {
+                assert_eq!(account.owner, solana_sdk_ids::native_loader::id());
+            }
+            Ok(None) => panic!("System program should exist"),
+            Err(e) => panic!("Failed to fetch system program: {:?}", e),
+        }
+
+        // Fetch a non-existent account.
+        let random_pubkey = Pubkey::new_unique();
+        let account = client.get_account(&random_pubkey).await.unwrap();
+        assert!(account.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_multiple_accounts() {
+        let client = RpcClient::new("https://api.mainnet-beta.solana.com");
+
+        let random_pubkey = Pubkey::new_unique();
+        let accounts = client
+            .get_multiple_accounts(&[SYSTEM_PROGRAM_ID, VOTE_PROGRAM_ID, random_pubkey])
+            .await
+            .unwrap();
+
+        assert_eq!(accounts.len(), 3);
+        assert!(accounts[0].is_some()); // System program exists
+        assert!(accounts[1].is_some()); // Vote program exists
+        assert!(accounts[2].is_none()); // Random account doesn't exist
+    }
+}

--- a/fetcher/serde/Cargo.toml
+++ b/fetcher/serde/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mollusk-svm-account-fetcher-serde"
+description = "Serde utilities for Mollusk SVM account fetchers"
+documentation = "https://docs.rs/mollusk-svm-account-fetcher-serde"
+authors = { workspace = true }
+repository = { workspace = true }
+readme = { workspace = true }
+license-file = { workspace = true }
+edition = { workspace = true }
+version = { workspace = true }
+
+[dependencies]
+base64 = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+solana-account = { workspace = true }
+solana-pubkey = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/fetcher/serde/src/lib.rs
+++ b/fetcher/serde/src/lib.rs
@@ -1,0 +1,169 @@
+//! Serde utilities for deserializing Solana accounts from JSON.
+
+use {base64::Engine, serde::Deserialize, solana_account::Account, solana_pubkey::Pubkey};
+
+/// Deserialize a Pubkey from a string.
+pub fn pubkey_from_str<'de, D>(deserializer: D) -> Result<Pubkey, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    s.parse::<Pubkey>().map_err(serde::de::Error::custom)
+}
+
+/// Solana CLI/RPC JSON account.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UiAccount {
+    pub lamports: u64,
+    pub data: Vec<String>,
+    #[serde(deserialize_with = "pubkey_from_str")]
+    pub owner: Pubkey,
+    pub executable: bool,
+    pub rent_epoch: u64,
+    #[serde(default)]
+    pub space: u64,
+}
+
+impl TryFrom<UiAccount> for Account {
+    type Error = base64::DecodeError;
+
+    fn try_from(ui_account: UiAccount) -> Result<Self, Self::Error> {
+        let data = if ui_account.data.len() == 2 && ui_account.data[1] == "base64" {
+            base64::engine::general_purpose::STANDARD.decode(&ui_account.data[0])?
+        } else {
+            Vec::new()
+        };
+
+        Ok(Account {
+            lamports: ui_account.lamports,
+            data,
+            owner: ui_account.owner,
+            executable: ui_account.executable,
+            rent_epoch: ui_account.rent_epoch,
+        })
+    }
+}
+
+/// Solana CLI/RPC JSON account and pubkey.
+#[derive(Debug, Deserialize)]
+pub struct KeyedUiAccount {
+    #[serde(deserialize_with = "pubkey_from_str")]
+    pub pubkey: Pubkey,
+    pub account: UiAccount,
+}
+
+impl TryFrom<KeyedUiAccount> for (Pubkey, Account) {
+    type Error = base64::DecodeError;
+
+    fn try_from(keyed: KeyedUiAccount) -> Result<Self, Self::Error> {
+        Ok((keyed.pubkey, keyed.account.try_into()?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, base64::Engine};
+
+    #[test]
+    fn test_deserialize_single_account() {
+        let pubkey = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let lamports = 1234567890;
+        let rent_epoch = 42;
+        let data = vec![1, 2, 3, 4, 5];
+        let data_base64 = base64::engine::general_purpose::STANDARD.encode(&data);
+        let space = data.len();
+
+        let json_content = format!(
+            r#"{{
+            "pubkey": "{pubkey}",
+            "account": {{
+                "lamports": {lamports},
+                "data": ["{data_base64}", "base64"],
+                "owner": "{owner}",
+                "executable": true,
+                "rentEpoch": {rent_epoch},
+                "space": {space}
+            }}
+        }}"#
+        );
+
+        let keyed_account: KeyedUiAccount = serde_json::from_str(&json_content).unwrap();
+        let (loaded_pubkey, account) = keyed_account.try_into().unwrap();
+
+        assert_eq!(loaded_pubkey, pubkey);
+        assert_eq!(account.lamports, lamports);
+        assert_eq!(account.data, data);
+        assert_eq!(account.owner, owner);
+        assert!(account.executable);
+        assert_eq!(account.rent_epoch, rent_epoch);
+    }
+
+    #[test]
+    fn test_deserialize_multiple_accounts() {
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+        let owner1 = Pubkey::new_unique();
+        let owner2 = Pubkey::new_unique();
+        let lamports1 = 1000000;
+        let lamports2 = 2000000;
+        let rent_epoch1 = 100;
+        let rent_epoch2 = 200;
+        let data1: Vec<u8> = vec![];
+        let data2 = vec![1, 2, 3];
+        let data2_base64 = base64::engine::general_purpose::STANDARD.encode(&data2);
+        let space1 = data1.len();
+        let space2 = data2.len();
+
+        let json_content = format!(
+            r#"[
+            {{
+                "pubkey": "{pubkey1}",
+                "account": {{
+                    "lamports": {lamports1},
+                    "data": ["", "base64"],
+                    "owner": "{owner1}",
+                    "executable": false,
+                    "rentEpoch": {rent_epoch1},
+                    "space": {space1}
+                }}
+            }},
+            {{
+                "pubkey": "{pubkey2}",
+                "account": {{
+                    "lamports": {lamports2},
+                    "data": ["{data2_base64}", "base64"],
+                    "owner": "{owner2}",
+                    "executable": true,
+                    "rentEpoch": {rent_epoch2},
+                    "space": {space2}
+                }}
+            }}
+        ]"#
+        );
+
+        let keyed_accounts: Vec<KeyedUiAccount> = serde_json::from_str(&json_content).unwrap();
+        let accounts: Vec<(Pubkey, Account)> = keyed_accounts
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(accounts.len(), 2);
+
+        assert_eq!(accounts[0].0, pubkey1);
+        assert_eq!(accounts[0].1.lamports, lamports1);
+        assert_eq!(accounts[0].1.data, data1);
+        assert_eq!(accounts[0].1.owner, owner1);
+        assert!(!accounts[0].1.executable);
+        assert_eq!(accounts[0].1.rent_epoch, rent_epoch1);
+
+        assert_eq!(accounts[1].0, pubkey2);
+        assert_eq!(accounts[1].1.lamports, lamports2);
+        assert_eq!(accounts[1].1.data, data2);
+        assert_eq!(accounts[1].1.owner, owner2);
+        assert!(accounts[1].1.executable);
+        assert_eq!(accounts[1].1.rent_epoch, rent_epoch2);
+    }
+}


### PR DESCRIPTION
Adds support for a handful of account fetching libraries, which should help developers obtain `Account` instances from common sources, such as fixtures and the Solana JSON-RPC.

cc @idatsy

---

Note I've intentionally reimplemented things like `UiAccount` and RPC types to avoid any heavy dependencies from Agave.