### PR TITLE
feat: epoch stake syscalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,16 +868,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "custom-syscall-program"
-version = "0.1.0"
-dependencies = [
- "solana-account-info",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey",
-]
-
-[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4305,6 +4295,26 @@ dependencies = [
 
 [[package]]
 name = "test-program-cpi-target"
+version = "0.1.0"
+dependencies = [
+ "solana-account-info",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "test-program-custom-syscall"
+version = "0.1.0"
+dependencies = [
+ "solana-account-info",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "test-program-epoch-stake"
 version = "0.1.0"
 dependencies = [
  "solana-account-info",

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ audit:
 build-test-programs:
 	@cargo build-sbf --manifest-path test-programs/cpi-target/Cargo.toml
 	@cargo build-sbf --manifest-path test-programs/custom-syscall/Cargo.toml
+	@cargo build-sbf --manifest-path test-programs/epoch-stake/Cargo.toml
 	@cargo build-sbf --manifest-path test-programs/primary/Cargo.toml
 
 # Pre-publish checks

--- a/harness/src/epoch_stake.rs
+++ b/harness/src/epoch_stake.rs
@@ -1,0 +1,31 @@
+use {solana_pubkey::Pubkey, std::collections::HashMap};
+
+/// A simple map of vote accounts to their epoch stake.
+///
+/// Developers can work with this map directly to configure stake for testing.
+/// The total epoch stake is calculated by summing all vote account stakes.
+pub type EpochStake = HashMap<Pubkey, u64>;
+
+/// Create an `EpochStake` instance with a few mocked-out vote accounts to
+/// achieve the provided total stake.
+pub fn create_mock_epoch_stake(target_total: u64) -> EpochStake {
+    let mut epoch_stake = HashMap::new();
+
+    if target_total == 0 {
+        return epoch_stake;
+    }
+
+    let num_accounts = target_total.div_ceil(1_000_000_000);
+
+    let base_stake = target_total / num_accounts;
+    let remainder = target_total % num_accounts;
+
+    std::iter::repeat(base_stake)
+        .take(num_accounts as usize - 1)
+        .chain(std::iter::once(base_stake + remainder))
+        .for_each(|stake| {
+            epoch_stake.insert(Pubkey::new_unique(), stake);
+        });
+
+    epoch_stake
+}

--- a/harness/tests/custom_syscall.rs
+++ b/harness/tests/custom_syscall.rs
@@ -44,7 +44,7 @@ fn test_custom_syscall() {
             .unwrap();
         mollusk.add_program(
             &program_id,
-            "custom_syscall_program",
+            "test_program_custom_syscall",
             &mollusk_svm::program::loader_keys::LOADER_V3,
         );
         mollusk

--- a/harness/tests/epoch_stake.rs
+++ b/harness/tests/epoch_stake.rs
@@ -1,0 +1,50 @@
+use {
+    mollusk_svm::{result::Check, Mollusk},
+    solana_account::Account,
+    solana_instruction::{AccountMeta, Instruction},
+    solana_pubkey::Pubkey,
+};
+
+#[test]
+fn test_epoch_stake() {
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+
+    let program_id = Pubkey::new_unique();
+    let mut mollusk = Mollusk::new(&program_id, "test_program_epoch_stake");
+
+    let key = Pubkey::new_unique();
+
+    let mut total_stake: u64 = 0;
+
+    for i in 1..=3 {
+        let stake = 1_000_000_000_000_000 * i;
+        total_stake += stake;
+
+        let vote_address = Pubkey::new_unique();
+
+        mollusk.epoch_stake.insert(vote_address, stake);
+        assert_eq!(total_stake, mollusk.epoch_stake.values().sum::<u64>());
+
+        let instruction = Instruction::new_with_bytes(
+            program_id,
+            &vote_address.to_bytes(),
+            vec![AccountMeta::new(key, false)],
+        );
+
+        mollusk.process_and_validate_instruction(
+            &instruction,
+            &[(key, Account::new(1_000, 16, &program_id))],
+            &[
+                Check::success(),
+                Check::account(&key)
+                    .data(&{
+                        let mut data = vec![0; 16];
+                        data[0..8].copy_from_slice(&total_stake.to_le_bytes());
+                        data[8..16].copy_from_slice(&stake.to_le_bytes());
+                        data
+                    })
+                    .build(),
+            ],
+        );
+    }
+}

--- a/test-programs/epoch-stake/Cargo.toml
+++ b/test-programs/epoch-stake/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test-program-custom-syscall"
+name = "test-program-epoch-stake"
 version = "0.1.0"
 edition = "2021"
 

--- a/test-programs/epoch-stake/src/lib.rs
+++ b/test-programs/epoch-stake/src/lib.rs
@@ -1,0 +1,34 @@
+#![cfg(target_os = "solana")]
+
+use {solana_account_info::AccountInfo, solana_program_error::ProgramError, solana_pubkey::Pubkey};
+
+extern "C" {
+    fn sol_get_epoch_stake(vote_address: *const u8) -> u64;
+}
+
+unsafe fn get_epoch_total_stake() -> u64 {
+    sol_get_epoch_stake(std::ptr::null::<Pubkey>() as *const u8)
+}
+
+unsafe fn get_epoch_stake_for_vote_account(vote_address: &Pubkey) -> u64 {
+    sol_get_epoch_stake(vote_address as *const _ as *const u8)
+}
+
+solana_program_entrypoint::entrypoint!(process_instruction);
+
+fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    input: &[u8],
+) -> Result<(), ProgramError> {
+    let vote_address = Pubkey::new_from_array(input.try_into().unwrap());
+
+    let total_stake = unsafe { get_epoch_total_stake() };
+    let vote_account_stake = unsafe { get_epoch_stake_for_vote_account(&vote_address) };
+
+    let mut data = accounts[0].try_borrow_mut_data()?;
+    data[0..8].copy_from_slice(&total_stake.to_le_bytes());
+    data[8..16].copy_from_slice(&vote_account_stake.to_le_bytes());
+
+    Ok(())
+}


### PR DESCRIPTION
Adds support for populating a cache of "epoch stakes", which can be used to serve the `sol_get_epoch_stake` syscall in program tests.