### PR TITLE
fix: add token-2022 program with loader v3

### DIFF
--- a/programs/token/src/token2022.rs
+++ b/programs/token/src/token2022.rs
@@ -9,7 +9,7 @@ pub fn add_program(mollusk: &mut Mollusk) {
     mollusk.add_program_with_elf_and_loader(
         &ID,
         ELF,
-        &mollusk_svm::program::loader_keys::LOADER_V2,
+        &mollusk_svm::program::loader_keys::LOADER_V3,
     );
 }
 


### PR DESCRIPTION
Use loader v3 to add token-2022 to align with onchain deployment