### PR TITLE
Fix Rent exempt check

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -577,8 +577,8 @@ impl Default for Mollusk {
 }
 
 impl CheckContext for Mollusk {
-    fn is_rent_exempt(&self, lamports: u64, space: usize) -> bool {
-        self.sysvars.rent.is_exempt(lamports, space)
+    fn is_rent_exempt(&self, lamports: u64, space: usize, owner: Pubkey) -> bool {
+        owner.eq(&Pubkey::default()) && lamports == 0 || self.sysvars.rent.is_exempt(lamports, space)
     }
 }
 

--- a/result/src/check.rs
+++ b/result/src/check.rs
@@ -253,7 +253,8 @@ impl InstructionResult {
                                     true,
                                     context.is_rent_exempt(
                                         resulting_account.lamports,
-                                        resulting_account.data.len()
+                                        resulting_account.data.len(),
+                                        resulting_account.owner,
                                     ),
                                 );
                             }

--- a/result/src/check.rs
+++ b/result/src/check.rs
@@ -282,7 +282,7 @@ impl InstructionResult {
                 CheckType::AllRentExempt => {
                     for (pubkey, account) in &self.resulting_accounts {
                         let is_rent_exempt =
-                            context.is_rent_exempt(account.lamports(), account.data().len());
+                            context.is_rent_exempt(account.lamports(), account.data().len(), account.owner);
                         if !is_rent_exempt {
                             pass &= throw!(
                                 c,

--- a/result/src/config.rs
+++ b/result/src/config.rs
@@ -1,5 +1,6 @@
 //! Configuration and context for result validation.
 
+use solana_pubkey::Pubkey;
 use solana_rent::Rent;
 
 pub struct Config {
@@ -24,8 +25,8 @@ impl Default for Config {
 /// one may wish to evaluate resulting account lamports with a custom `Rent`
 /// configuration. This trait allows such customization.
 pub trait CheckContext {
-    fn is_rent_exempt(&self, lamports: u64, space: usize) -> bool {
-        Rent::default().is_exempt(lamports, space)
+    fn is_rent_exempt(&self, lamports: u64, space: usize, owner: Pubkey) -> bool {
+        owner.eq(&Pubkey::default()) && lamports == 0 || Rent::default().is_exempt(lamports, space)
     }
 }
 


### PR DESCRIPTION
Currently in Mollusk, when we run a `Check::rent_exempt` or `Check::all_rent_exempt` on an execution result, it will return a false negative for accounts that belong to `SystemProgram` with a lamport balance of `0`, such as uninitialized PDAs that are used only for signing purposes. In a regular validator environment, such accounts would simply be cleaned up and would not result in an error. In order to replicate this functionality in Mollusk, I have modified the rent exempt checks to not return an error in such cases.