### PR TITLE
fixes typo

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -616,7 +616,7 @@ impl InvokeContextCallback for MolluskInvokeContextCallback<'_> {
 impl Mollusk {
     /// Create a new Mollusk instance containing the provided program.
     ///
-    /// Attempts the load the program's ELF file from the default search paths.
+    /// Attempts to load the program's ELF file from the default search paths.
     /// Once loaded, adds the program to the program cache and returns the
     /// newly created Mollusk instance.
     ///


### PR DESCRIPTION
"the" -> "to" 


david says I got a sharp eye : )
<img width="855" height="272" alt="image" src="https://github.com/user-attachments/assets/b6d8e297-ac48-4e9b-beae-778e5267b10c" />
