### PR TITLE
feat: account-store: load sysvar and program accounts automatically

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -1195,9 +1195,17 @@ impl<AS: AccountStore> MolluskContext<AS> {
                 .iter()
                 .for_each(|AccountMeta { pubkey, .. }| {
                     if seen.insert(*pubkey) {
-                        let account = store
-                            .get_account(pubkey)
-                            .unwrap_or_else(|| store.default_account(pubkey));
+                        let account = store.get_account(pubkey).unwrap_or_else(|| {
+                            self.mollusk
+                                .sysvars
+                                .maybe_create_sysvar_account(pubkey)
+                                .unwrap_or_else(|| {
+                                    self.mollusk
+                                        .program_cache
+                                        .maybe_create_program_account(pubkey)
+                                        .unwrap_or_else(|| store.default_account(pubkey))
+                                })
+                        });
                         accounts.push((*pubkey, account));
                     }
                 });

--- a/harness/src/program.rs
+++ b/harness/src/program.rs
@@ -164,6 +164,24 @@ impl ProgramCache {
             })
             .collect()
     }
+
+    pub(crate) fn maybe_create_program_account(&self, pubkey: &Pubkey) -> Option<Account> {
+        // If it's found in the entries cache, create the proper program account based
+        // on the loader key.
+        self.entries_cache
+            .borrow()
+            .get(pubkey)
+            .map(|loader_key| match *loader_key {
+                loader_keys::NATIVE_LOADER => {
+                    create_keyed_account_for_builtin_program(pubkey, "I'm a stub!").1
+                }
+                loader_keys::LOADER_V1 => create_program_account_loader_v1(&[]),
+                loader_keys::LOADER_V2 => create_program_account_loader_v2(&[]),
+                loader_keys::LOADER_V3 => create_program_account_loader_v3(pubkey),
+                loader_keys::LOADER_V4 => create_program_account_loader_v4(&[]),
+                _ => panic!("Invalid loader key: {}", loader_key),
+            })
+    }
 }
 
 pub struct Builtin {

--- a/harness/src/sysvar.rs
+++ b/harness/src/sysvar.rs
@@ -72,6 +72,26 @@ impl Sysvars {
         (T::id(), account)
     }
 
+    pub(crate) fn maybe_create_sysvar_account(&self, pubkey: &Pubkey) -> Option<Account> {
+        if pubkey.eq(&Clock::id()) {
+            Some(self.sysvar_account(&self.clock).1)
+        } else if pubkey.eq(&EpochRewards::id()) {
+            Some(self.sysvar_account(&self.epoch_rewards).1)
+        } else if pubkey.eq(&EpochSchedule::id()) {
+            Some(self.sysvar_account(&self.epoch_schedule).1)
+        } else if pubkey.eq(&LastRestartSlot::id()) {
+            Some(self.sysvar_account(&self.last_restart_slot).1)
+        } else if pubkey.eq(&Rent::id()) {
+            Some(self.sysvar_account(&self.rent).1)
+        } else if pubkey.eq(&SlotHashes::id()) {
+            Some(self.sysvar_account(&self.slot_hashes).1)
+        } else if pubkey.eq(&StakeHistory::id()) {
+            Some(self.sysvar_account(&self.stake_history).1)
+        } else {
+            None
+        }
+    }
+
     /// Get the key and account for the clock sysvar.
     pub fn keyed_account_for_clock_sysvar(&self) -> (Pubkey, Account) {
         self.sysvar_account(&self.clock)

--- a/harness/tests/account_store.rs
+++ b/harness/tests/account_store.rs
@@ -127,6 +127,72 @@ fn test_multiple_transfers_with_persistent_state() {
 }
 
 #[test]
+fn test_account_store_sysvar_account() {
+    let mollusk = Mollusk::default();
+    let context = mollusk.with_context(HashMap::new());
+
+    // Use Clock sysvar as an example.
+    let clock_pubkey = solana_sdk_ids::sysvar::clock::id();
+    let recipient = Pubkey::new_unique();
+
+    // Create an instruction that references the Clock sysvar.
+    let instruction = solana_instruction::Instruction::new_with_bytes(
+        solana_sdk_ids::system_program::id(),
+        &[],
+        vec![
+            solana_instruction::AccountMeta::new_readonly(clock_pubkey, false),
+            solana_instruction::AccountMeta::new(recipient, false),
+        ],
+    );
+
+    // Process the instruction - this should load the Clock sysvar account.
+    context.process_instruction(&instruction);
+
+    // Verify the Clock sysvar was loaded correctly.
+    let store = context.account_store.borrow();
+    let clock_account = store.get(&clock_pubkey).expect("Clock sysvar should exist");
+
+    // Verify it has the expected owner.
+    assert_eq!(clock_account.owner, solana_sdk_ids::sysvar::id());
+    // Verify it has data (Clock sysvar should have serialized Clock data).
+    assert!(!clock_account.data.is_empty());
+}
+
+#[test]
+fn test_account_store_program_account() {
+    // Use the System Program as an example.
+    let program_id = solana_sdk_ids::system_program::id();
+    let mollusk = Mollusk::default();
+
+    let context = mollusk.with_context(HashMap::new());
+    let recipient = Pubkey::new_unique();
+
+    // Create an instruction that references the program account.
+    let instruction = solana_instruction::Instruction::new_with_bytes(
+        solana_sdk_ids::bpf_loader_upgradeable::id(),
+        &[],
+        vec![
+            solana_instruction::AccountMeta::new_readonly(program_id, false),
+            solana_instruction::AccountMeta::new(recipient, false),
+        ],
+    );
+
+    // Process the instruction - this should load the program account.
+    context.process_instruction(&instruction);
+
+    // Verify the program account was loaded correctly
+    let store = context.account_store.borrow();
+    let program_account = store
+        .get(&program_id)
+        .expect("Program account should exist");
+
+    // Verify it has the expected owner (native loader for builtins).
+    assert_eq!(program_account.owner, solana_sdk_ids::native_loader::id());
+    // Verify it's marked as executable.
+    assert!(program_account.executable);
+}
+
+#[test]
 fn test_account_store_default_account() {
     let mollusk = Mollusk::default();
     let context = mollusk.with_context(HashMap::new());


### PR DESCRIPTION
#### Problem

Currently, developers using an account store would have to pre-load the store with program accounts for the programs they expect to use, and right before each invocation they'd have to add a sysvar account using the current sysvar data stored in the Mollusk instance. This is obviously brittle and a terrible developer experience.

#### Summary of Changes

Like before, attempt to load an account from the store before doing anything else. However, if that load returns `None`, check if the address is a sysvar ID. If it is, create the account from the active sysvars. Next, check if it's a known (cached) program ID. If it is, create the program account from the cached loader ID. Finally, resort to the default account.