### PR TITLE
Use 3.0 crates and 2.0 SPL interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,65 +18,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm-siv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "polyval",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "agave-feature-set"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305be18924e302fbc082a145f9c747fabedfaf136dbcb3820134db2d9855a44b"
+checksum = "85c1a889e5b7a9ceecc95a39bb617af24d3195e3e7af116e2843976fb4fd1fec"
 dependencies = [
  "ahash",
  "solana-epoch-schedule",
  "solana-hash",
  "solana-pubkey",
- "solana-sha256-hasher",
- "solana-svm-feature-set",
+ "solana-sha256-hasher 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-svm-feature-set 3.0.0",
+]
+
+[[package]]
+name = "agave-feature-set"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/agave.git#b676359b1fef681acc0fc97af4b3cf0a080857b7"
+dependencies = [
+ "ahash",
+ "solana-epoch-schedule",
+ "solana-hash",
+ "solana-pubkey",
+ "solana-sha256-hasher 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-svm-feature-set 3.1.0",
 ]
 
 [[package]]
 name = "agave-precompiles"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36b72ead0da029d1dab286a094bb330702a037d121043183343a60c429fd69"
+checksum = "786ca0e8053b48d99829b6f6b7313d3f086fe0a4e22ef3c9992faceed76b72cf"
 dependencies = [
- "agave-feature-set",
+ "agave-feature-set 3.0.0",
  "bincode",
  "digest 0.10.7",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "libsecp256k1",
  "openssl",
  "sha3",
@@ -84,9 +61,52 @@ dependencies = [
  "solana-message",
  "solana-precompile-error",
  "solana-pubkey",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-secp256k1-program",
  "solana-secp256r1-program",
+]
+
+[[package]]
+name = "agave-syscalls"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c09b9517973a1486b3e1b232d95db032c3ed8d208b1169c18e533f05dccfe5"
+dependencies = [
+ "bincode",
+ "libsecp256k1",
+ "num-traits",
+ "solana-account",
+ "solana-account-info",
+ "solana-big-mod-exp",
+ "solana-blake3-hasher",
+ "solana-bn254",
+ "solana-clock",
+ "solana-cpi",
+ "solana-curve25519",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keccak-hasher",
+ "solana-loader-v3-interface",
+ "solana-poseidon",
+ "solana-program-entrypoint",
+ "solana-program-runtime 3.0.0",
+ "solana-pubkey",
+ "solana-sbpf",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-secp256k1-recover",
+ "solana-sha256-hasher 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-stable-layout",
+ "solana-stake-interface",
+ "solana-svm-callback 3.0.0",
+ "solana-svm-feature-set 3.0.0",
+ "solana-svm-log-collector 3.0.0",
+ "solana-svm-measure 3.0.0",
+ "solana-svm-timings 3.0.0",
+ "solana-svm-type-overrides 3.0.0",
+ "solana-sysvar",
+ "solana-sysvar-id",
+ "solana-transaction-context 3.0.0",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -352,17 +372,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +409,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bincode"
@@ -421,7 +442,6 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -440,74 +460,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "borsh"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
-dependencies = [
- "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "borsh"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
-dependencies = [
- "borsh-derive 1.5.7",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831213f80d9423998dd696e2c5345aba6be7a0bd8cd19e31c5243e13df1cef89"
-dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
-dependencies = [
- "once_cell",
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d6ba50644c98714aa2a70d13d7df3cd75cd2b523a2b452bf010443800976b3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276691d96f063427be83e6692b86148e488ebba9f48f77788724ca027ba3b6d4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -558,18 +510,18 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -616,6 +568,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cfg_eval"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,16 +617,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -726,24 +679,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
+name = "const-oid"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "console_log"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89f72f65e8501878b8a004d5a1afb780987e2ce2b4532c562e367a72c57499f"
-dependencies = [
- "log",
- "web-sys",
-]
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
@@ -852,13 +791,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -870,15 +820,6 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array",
  "subtle",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -924,6 +865,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,10 +913,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivation-path"
-version = "0.2.0"
+name = "der"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "derivative"
@@ -969,6 +949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -980,12 +961,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abe71d579d1812060163dff96056261deb5bf6729b100fa2e36a68b9649ba3d3"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 2.2.0",
+ "spki",
+]
+
+[[package]]
 name = "ed25519"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -995,10 +1000,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek 3.2.0",
- "ed25519",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.8",
+ "subtle",
  "zeroize",
 ]
 
@@ -1007,6 +1027,25 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "enum-iterator"
@@ -1029,16 +1068,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.3"
+name = "env_filter"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
- "atty",
- "humantime",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -1068,6 +1117,16 @@ name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1230,6 +1289,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1287,6 +1347,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,15 +1405,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1516,6 +1578,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,15 +1601,6 @@ checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -1612,13 +1671,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "kaigan"
-version = "0.2.6"
+name = "k256"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba15de5aeb137f0f65aa3bf82187647f1285abfe5b20c80c2c37f7007ad519a"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
- "borsh 0.10.4",
- "serde",
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2 0.10.8",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1746,27 +1809,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,11 +1833,12 @@ dependencies = [
 name = "mollusk-svm"
 version = "0.5.1"
 dependencies = [
- "agave-feature-set",
+ "agave-feature-set 3.0.0",
  "agave-precompiles",
+ "agave-syscalls",
  "bincode",
  "criterion",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "libsecp256k1",
  "mollusk-svm-error",
  "mollusk-svm-fuzz-fixture",
@@ -1817,29 +1860,31 @@ dependencies = [
  "solana-epoch-schedule",
  "solana-hash",
  "solana-instruction",
- "solana-loader-v3-interface 3.0.0",
+ "solana-instruction-error",
+ "solana-loader-v3-interface",
  "solana-loader-v4-interface",
- "solana-log-collector",
  "solana-logger",
  "solana-native-token",
  "solana-precompile-error",
  "solana-program-error",
- "solana-program-runtime",
+ "solana-program-runtime 3.0.0",
  "solana-pubkey",
  "solana-rent",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-secp256k1-program",
  "solana-secp256r1-program",
+ "solana-sha256-hasher 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-slot-hashes",
  "solana-stake-interface",
  "solana-stake-program",
- "solana-svm-callback",
- "solana-system-interface",
+ "solana-svm-callback 3.0.0",
+ "solana-svm-log-collector 3.0.0",
+ "solana-svm-timings 3.0.0",
+ "solana-system-interface 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-system-program",
  "solana-sysvar",
  "solana-sysvar-id",
- "solana-timings",
- "solana-transaction-context",
+ "solana-transaction-context 3.0.0",
 ]
 
 [[package]]
@@ -1871,7 +1916,7 @@ dependencies = [
  "serde_yaml",
  "solana-logger",
  "solana-pubkey",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
 ]
 
@@ -1887,7 +1932,7 @@ dependencies = [
 name = "mollusk-svm-fuzz-fixture"
 version = "0.5.1"
 dependencies = [
- "agave-feature-set",
+ "agave-feature-set 3.0.0",
  "mollusk-svm-fuzz-fs",
  "prost",
  "prost-build",
@@ -1911,7 +1956,7 @@ dependencies = [
 name = "mollusk-svm-fuzz-fixture-firedancer"
 version = "0.5.1"
 dependencies = [
- "agave-feature-set",
+ "agave-feature-set 3.0.0",
  "mollusk-svm-fuzz-fs",
  "prost",
  "prost-build",
@@ -1920,7 +1965,7 @@ dependencies = [
  "solana-account",
  "solana-keccak-hasher",
  "solana-pubkey",
- "solana-transaction-context",
+ "solana-transaction-context 3.0.0",
  "which",
 ]
 
@@ -1943,7 +1988,7 @@ dependencies = [
  "solana-account",
  "solana-instruction",
  "solana-pubkey",
- "solana-transaction-context",
+ "solana-transaction-context 3.0.0",
 ]
 
 [[package]]
@@ -1961,10 +2006,11 @@ version = "0.5.1"
 dependencies = [
  "mollusk-svm",
  "solana-account",
+ "solana-program-pack",
  "solana-pubkey",
  "solana-rent",
- "spl-associated-token-account",
- "spl-token",
+ "spl-associated-token-account-interface",
+ "spl-token-interface",
 ]
 
 [[package]]
@@ -2109,7 +2155,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -2266,6 +2312,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,33 +2356,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
 ]
 
 [[package]]
@@ -2401,15 +2436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qstring"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "qualifier_attr"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2434,7 +2460,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "web-time",
@@ -2455,7 +2481,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2650,9 +2676,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -2688,6 +2714,16 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -2802,6 +2838,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,6 +2908,29 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2964,6 +3037,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2990,9 +3073,8 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f949fe4edaeaea78c844023bfc1c898e0b1f5a100f8a8d2d0f85d0a7b090258"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -3001,210 +3083,181 @@ dependencies = [
  "serde_derive",
  "solana-account-info",
  "solana-clock",
- "solana-instruction",
+ "solana-instruction-error",
  "solana-pubkey",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
  "solana-sysvar",
 ]
 
 [[package]]
 name = "solana-account-info"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c17d606a298a205fae325489fbed88ee6dc4463c111672172327e741c8905d"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
- "bincode",
- "serde",
  "solana-program-error",
  "solana-program-memory",
  "solana-pubkey",
 ]
 
 [[package]]
-name = "solana-address-lookup-table-interface"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1673f67efe870b64a65cb39e6194be5b26527691ce5922909939961a6e6b395"
+name = "solana-address"
+version = "1.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
- "bincode",
  "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek 4.1.3",
+ "five8",
+ "five8_const",
  "serde",
  "serde_derive",
- "solana-clock",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-slot-hashes",
+ "solana-atomic-u64",
+ "solana-define-syscall 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
+ "solana-program-error",
+ "solana-sanitize",
+ "solana-sha256-hasher 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
 ]
 
 [[package]]
 name = "solana-atomic-u64"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52e52720efe60465b052b9e7445a01c17550666beec855cce66f44766697bc2"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "solana-big-mod-exp"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db7f2bbac3e62cfd139065d15bcda9e2428883ba61fc8d27ccb251081e7567"
+checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-bincode"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a3787b8cf9c9fe3dd360800e8b70982b9e5a8af9e11c354b6665dd4a003adc"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "bincode",
  "serde",
- "solana-instruction",
+ "solana-instruction-error",
 ]
 
 [[package]]
 name = "solana-blake3-hasher"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0801e25a1b31a14494fc80882a036be0ffd290efc4c2d640bfcca120a4672"
+checksum = "ffa2e3bdac3339c6d0423275e45dafc5ac25f4d43bf344d026a3cc9a85e244a6"
 dependencies = [
  "blake3",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash",
- "solana-sanitize",
 ]
 
 [[package]]
 name = "solana-bn254"
-version = "2.2.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4420f125118732833f36facf96a27e7b78314b2d642ba07fa9ffdacd8d79e243"
+checksum = "20a5f01e99addb316d95d4ed31aa6eacfda557fffc00ae316b919e8ba0fc5b91"
 dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",
  "bytemuck",
- "solana-define-syscall",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-borsh"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718333bcd0a1a7aed6655aa66bef8d7fb047944922b2d3a18f49cbc13e73d004"
-dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.7",
+ "solana-define-syscall 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f64ed51006b8cd4e65b0750b789c15501935c423bdd643572d31ad75e692f4b"
+checksum = "4528133cc0e540525f9eb9013ffcaa3708615f5e4aa4926d93b16ac059cbe299"
 dependencies = [
+ "agave-syscalls",
  "bincode",
- "libsecp256k1",
- "num-traits",
  "qualifier_attr",
- "scopeguard",
  "solana-account",
- "solana-account-info",
- "solana-big-mod-exp",
  "solana-bincode",
- "solana-blake3-hasher",
- "solana-bn254",
  "solana-clock",
- "solana-cpi",
- "solana-curve25519",
- "solana-hash",
  "solana-instruction",
- "solana-keccak-hasher",
- "solana-loader-v3-interface 5.0.0",
+ "solana-loader-v3-interface",
  "solana-loader-v4-interface",
- "solana-log-collector",
- "solana-measure",
  "solana-packet",
- "solana-poseidon",
  "solana-program-entrypoint",
- "solana-program-runtime",
+ "solana-program-runtime 3.0.0",
  "solana-pubkey",
  "solana-sbpf",
- "solana-sdk-ids",
- "solana-secp256k1-recover",
- "solana-sha256-hasher",
- "solana-stable-layout",
- "solana-svm-feature-set",
- "solana-system-interface",
- "solana-sysvar",
- "solana-sysvar-id",
- "solana-timings",
- "solana-transaction-context",
- "solana-type-overrides",
- "thiserror 2.0.12",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-svm-feature-set 3.0.0",
+ "solana-svm-log-collector 3.0.0",
+ "solana-svm-measure 3.0.0",
+ "solana-svm-type-overrides 3.0.0",
+ "solana-system-interface 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-transaction-context 3.0.0",
 ]
 
 [[package]]
 name = "solana-clock"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb482ab70fced82ad3d7d3d87be33d466a3498eb8aa856434ff3c0dfc2e2e31"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-cluster-type"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ace9fea2daa28354d107ea879cff107181d85cd4e0f78a2bedb10e1a428c97e"
+checksum = "eb7692fa6bf10a1a86b450c4775526f56d7e0e2116a53313f2533b5694abea64"
 dependencies = [
  "solana-hash",
 ]
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956fab24ae74baa5b1f611b988365dc0b699977329ef9a3dec30d259e4236804"
+checksum = "8c1f2216bb68fb61ba79c91709ded40271e5aac1bf3ca20f3f84a13ec4ae8e8b"
 dependencies = [
  "solana-fee-structure",
- "solana-program-runtime",
+ "solana-program-runtime 3.0.0",
 ]
 
 [[package]]
-name = "solana-config-program-client"
-version = "0.0.2"
+name = "solana-config-interface"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53aceac36f105fd4922e29b4f0c1f785b69d7b3e7e387e384b8985c8e0c3595e"
+checksum = "63e401ae56aed512821cc7a0adaa412ff97fecd2dff4602be7b1330d2daec0c4"
 dependencies = [
  "bincode",
- "borsh 0.10.4",
- "kaigan",
  "serde",
- "solana-program",
+ "serde_derive",
+ "solana-account",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-short-vec",
+ "solana-system-interface 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-cpi"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc71126edddc2ba014622fc32d0f5e2e78ec6c5a1e0eb511b85618c09e9ea11"
+checksum = "16238feb63d1cbdf915fb287f29ef7a7ebf81469bd6214f8b72a53866b593f8f"
 dependencies = [
  "solana-account-info",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
@@ -3213,145 +3266,79 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b575bfa3a3775e4201cd5179d4d390a056b8dc691a3df8ac754e8d7e629454"
+checksum = "2dab05c4022aaf34512f8237b868758d638839ce55e3e30bf26e14a8f7a81250"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-decode-error"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a6a6383af236708048f8bd8d03db8ca4ff7baf4a48e5d580f4cce545925470"
-dependencies = [
- "num-traits",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "solana-define-syscall"
-version = "2.3.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae3e2abcf541c8122eafe9a625d4d194b4023c20adde1e251f94e056bb1aee2"
+checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
 
 [[package]]
-name = "solana-derivation-path"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "939756d798b25c5ec3cca10e06212bdca3b1443cb9bb740a38124f58b258737b"
-dependencies = [
- "derivation-path",
- "qstring",
- "uriparse",
-]
+name = "solana-define-syscall"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 
 [[package]]
 name = "solana-ed25519-program"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feafa1691ea3ae588f99056f4bdd1293212c7ece28243d7da257c443e84753"
+checksum = "e1419197f1c06abf760043f6d64ba9d79a03ad5a43f18c7586471937122094da"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
- "ed25519-dalek",
- "solana-feature-set",
  "solana-instruction",
- "solana-precompile-error",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-epoch-rewards"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b575d3dd323b9ea10bb6fe89bf6bf93e249b215ba8ed7f68f1a3633f384db7"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-hash",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-epoch-schedule"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce071fbddecc55d727b1d7ed16a629afe4f6e4c217bc8d00af3b785f6f67ed"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
-name = "solana-example-mocks"
-version = "2.2.1"
+name = "solana-fee-calculator"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84461d56cbb8bb8d539347151e0525b53910102e4bced875d49d5139708e39d3"
+checksum = "2a73cc03ca4bed871ca174558108835f8323e85917bb38b9c81c7af2ab853efe"
 dependencies = [
- "serde",
- "serde_derive",
- "solana-address-lookup-table-interface",
- "solana-clock",
- "solana-hash",
- "solana-instruction",
- "solana-keccak-hasher",
- "solana-message",
- "solana-nonce",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-feature-gate-interface"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f5c5382b449e8e4e3016fb05e418c53d57782d8b5c30aa372fc265654b956d"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-feature-set"
-version = "2.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f6c09cc41059c0e03ccbee7f5d4cc0a315d68ef0d59b67eb90246adfd8cc35"
-dependencies = [
- "ahash",
- "lazy_static",
- "solana-epoch-schedule",
- "solana-hash",
- "solana-pubkey",
- "solana-sha256-hasher",
+ "log",
 ]
 
 [[package]]
 name = "solana-fee-calculator"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89bc408da0fb3812bc3008189d148b4d3e08252c79ad810b245482a3f70cd8d"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "log",
  "serde",
@@ -3360,19 +3347,15 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-structure"
-version = "2.3.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33adf673581c38e810bf618f745bf31b683a0a4a4377682e6aaac5d9a058dd4e"
-dependencies = [
- "solana-message",
- "solana-native-token",
-]
+checksum = "5e2abdb1223eea8ec64136f39cb1ffcf257e00f915c957c35c0dd9e3f4e700b0"
 
 [[package]]
 name = "solana-genesis-config"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968dabd2b92d57131473eddbd475339da530e14f54397386abf303de3a2595a2"
+checksum = "749eccc960e85c9b33608450093d256006253e1cb436b8380e71777840a3f675"
 dependencies = [
  "bincode",
  "chrono",
@@ -3381,17 +3364,15 @@ dependencies = [
  "solana-clock",
  "solana-cluster-type",
  "solana-epoch-schedule",
- "solana-fee-calculator",
+ "solana-fee-calculator 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash",
  "solana-inflation",
  "solana-keypair",
- "solana-logger",
- "solana-native-token",
  "solana-poh-config",
  "solana-pubkey",
  "solana-rent",
- "solana-sdk-ids",
- "solana-sha256-hasher",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sha256-hasher 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-shred-version",
  "solana-signer",
  "solana-time-utils",
@@ -3399,182 +3380,142 @@ dependencies = [
 
 [[package]]
 name = "solana-hard-forks"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c28371f878e2ead55611d8ba1b5fb879847156d04edea13693700ad1a28baf"
+checksum = "0abacc4b66ce471f135f48f22facf75cbbb0f8a252fbe2c1e0aa59d5b203f519"
 
 [[package]]
 name = "solana-hash"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b96e9f0300fa287b545613f007dfe20043d7812bee255f418c1eb649c93b63"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
- "borsh 1.5.7",
  "bytemuck",
  "bytemuck_derive",
  "five8",
- "js-sys",
  "serde",
  "serde_derive",
  "solana-atomic-u64",
  "solana-sanitize",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-inflation"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23eef6a09eb8e568ce6839573e4966850e85e9ce71e6ae1a6c930c1c43947de3"
+checksum = "e92f37a14e7c660628752833250dd3dcd8e95309876aee751d7f8769a27947c6"
 
 [[package]]
 name = "solana-instruction"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47298e2ce82876b64f71e9d13a46bc4b9056194e7f9937ad3084385befa50885"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "bincode",
- "borsh 1.5.7",
- "getrandom 0.2.15",
- "js-sys",
+ "serde",
+ "serde_derive",
+ "solana-define-syscall 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
+ "solana-instruction-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-instruction-error"
+version = "2.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
+dependencies = [
  "num-traits",
  "serde",
  "serde_derive",
- "solana-define-syscall",
- "solana-pubkey",
- "wasm-bindgen",
+ "solana-program-error",
 ]
 
 [[package]]
 name = "solana-instructions-sysvar"
-version = "2.2.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e85a6fad5c2d0c4f5b91d34b8ca47118fc593af706e523cdbedf846a954f57"
+checksum = "7ddf67876c541aa1e21ee1acae35c95c6fbc61119814bfef70579317a5e26955"
 dependencies = [
  "bitflags",
  "solana-account-info",
  "solana-instruction",
+ "solana-instruction-error",
  "solana-program-error",
  "solana-pubkey",
  "solana-sanitize",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-serialize-utils",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-keccak-hasher"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7aeb957fbd42a451b99235df4942d96db7ef678e8d5061ef34c9b34cae12f79"
+checksum = "57eebd3012946913c8c1b8b43cdf8a6249edb09c0b6be3604ae910332a3acd97"
 dependencies = [
  "sha3",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-hash",
- "solana-sanitize",
 ]
 
 [[package]]
 name = "solana-keypair"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dbb7042c2e0c561afa07242b2099d55c57bd1b1da3b6476932197d84e15e3e4"
+checksum = "80eaf45d386c94e59c0c2d3db4a76c05f90365394aa848edce5826d3f7e77fb3"
 dependencies = [
- "bs58",
- "ed25519-dalek",
- "rand 0.7.3",
+ "ed25519-dalek 2.2.0",
+ "five8",
+ "rand 0.8.5",
  "solana-pubkey",
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-last-restart-slot"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6360ac2fdc72e7463565cd256eedcf10d7ef0c28a1249d261ec168c1b55cdd"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
-name = "solana-loader-v2-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ab08006dad78ae7cd30df8eea0539e207d08d91eaefb3e1d49a446e1c49654"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
 name = "solana-loader-v3-interface"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4be76cfa9afd84ca2f35ebc09f0da0f0092935ccdac0595d98447f259538c2"
+version = "6.1.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
  "solana-instruction",
  "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-loader-v3-interface"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7162a05b8b0773156b443bccd674ea78bb9aa406325b467ea78c06c99a63a2"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
 ]
 
 [[package]]
 name = "solana-loader-v4-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706a777242f1f39a83e2a96a2a6cb034cb41169c6ecbee2cf09cb873d9659e7e"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
  "solana-instruction",
  "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-log-collector"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7b7fd84dc54f43c26417460cb1b420cf7abf193395155a7ba94ceb105e3568"
-dependencies = [
- "log",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
+ "solana-system-interface 2.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8e777ec1afd733939b532a42492d888ec7c88d8b4127a5d867eb45c6eb5cd5"
+checksum = "ef7421d1092680d72065edbf5c7605856719b021bf5f173656c71febcdd5d003"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -3584,270 +3525,150 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-measure"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b595ca49ec02c6f3f31c6ff7788186b982ad211600c8d885baf389171af8a52"
-
-[[package]]
 name = "solana-message"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1796aabce376ff74bf89b78d268fa5e683d7d7a96a0a4e4813ec34de49d5314b"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
- "bincode",
- "blake3",
  "lazy_static",
- "serde",
- "serde_derive",
- "solana-bincode",
  "solana-hash",
  "solana-instruction",
  "solana-pubkey",
  "solana-sanitize",
- "solana-sdk-ids",
- "solana-short-vec",
- "solana-system-interface",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
  "solana-transaction-error",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-metrics"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c243a2c15e66f6db2c8b11b92c27bbf737b28fff0b39952a294e4befb8c46"
-dependencies = [
- "crossbeam-channel",
- "gethostname",
- "log",
- "reqwest",
- "solana-cluster-type",
- "solana-sha256-hasher",
- "solana-time-utils",
- "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "solana-msg"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36a1a14399afaabc2781a1db09cb14ee4cc4ee5c7a5a3cfcc601811379a8092"
+checksum = "264275c556ea7e22b9d3f87d56305546a38d4eee8ec884f3b126236cb7dcbbb4"
 dependencies = [
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-msg"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
+dependencies = [
+ "solana-define-syscall 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
 ]
 
 [[package]]
 name = "solana-native-token"
-version = "2.3.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61515b880c36974053dd499c0510066783f0cc6ac17def0c7ef2a244874cf4a9"
+checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-nonce"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703e22eb185537e06204a5bd9d509b948f0066f2d1d814a6f475dafb3ddf1325"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-fee-calculator",
+ "solana-fee-calculator 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
  "solana-hash",
  "solana-pubkey",
- "solana-sha256-hasher",
+ "solana-sha256-hasher 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
 ]
 
 [[package]]
 name = "solana-nonce-account"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde971a20b8dbf60144d6a84439dda86b5466e00e2843091fe731083cda614da"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "solana-account",
  "solana-hash",
  "solana-nonce",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
 ]
 
 [[package]]
 name = "solana-packet"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004f2d2daf407b3ec1a1ca5ec34b3ccdfd6866dd2d3c7d0715004a96e4b6d127"
+checksum = "6edf2f25743c95229ac0fdc32f8f5893ef738dbf332c669e9861d33ddb0f469d"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "solana-poh-config"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d650c3b4b9060082ac6b0efbbb66865089c58405bfb45de449f3f2b91eccee75"
+checksum = "2f1fef1f2ff2480fdbcc64bef5e3c47bec6e1647270db88b43f23e3a55f8d9cf"
 
 [[package]]
 name = "solana-poseidon"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a44faa88ef8d2b0bbc50d6e43fc24adcaf76a716e3d77af23d670e5f9adc36"
+checksum = "6ff32717f251f272e52d0c668befe78ec1e060544dd763671e75d88fda04063c"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
- "solana-define-syscall",
- "thiserror 2.0.12",
+ "solana-define-syscall 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "solana-precompile-error"
-version = "2.2.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d87b2c1f5de77dfe2b175ee8dd318d196aaca4d0f66f02842f80c852811f9f8"
+checksum = "cafcd950de74c6c39d55dc8ca108bbb007799842ab370ef26cf45a34453c31e1"
 dependencies = [
  "num-traits",
- "solana-decode-error",
-]
-
-[[package]]
-name = "solana-program"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98eca145bd3545e2fbb07166e895370576e47a00a7d824e325390d33bf467210"
-dependencies = [
- "bincode",
- "blake3",
- "borsh 0.10.4",
- "borsh 1.5.7",
- "bs58",
- "bytemuck",
- "console_error_panic_hook",
- "console_log",
- "getrandom 0.2.15",
- "lazy_static",
- "log",
- "memoffset",
- "num-bigint 0.4.6",
- "num-derive",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-account-info",
- "solana-address-lookup-table-interface",
- "solana-atomic-u64",
- "solana-big-mod-exp",
- "solana-bincode",
- "solana-blake3-hasher",
- "solana-borsh",
- "solana-clock",
- "solana-cpi",
- "solana-decode-error",
- "solana-define-syscall",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-example-mocks",
- "solana-feature-gate-interface",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-keccak-hasher",
- "solana-last-restart-slot",
- "solana-loader-v2-interface",
- "solana-loader-v3-interface 5.0.0",
- "solana-loader-v4-interface",
- "solana-message",
- "solana-msg",
- "solana-native-token",
- "solana-nonce",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-secp256k1-recover",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-sha256-hasher",
- "solana-short-vec",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stable-layout",
- "solana-stake-interface",
- "solana-system-interface",
- "solana-sysvar",
- "solana-sysvar-id",
- "solana-vote-interface",
- "thiserror 2.0.12",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-program-entrypoint"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473ffe73c68d93e9f2aa726ad2985fe52760052709aaab188100a42c618060ec"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "solana-account-info",
- "solana-msg",
+ "solana-define-syscall 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
+ "solana-msg 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
  "solana-program-error",
  "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-program-error"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ae2c1a8d0d4ae865882d5770a7ebca92bab9c685e43f0461682c6c05a35bfa"
-dependencies = [
- "borsh 1.5.7",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-pubkey",
-]
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 
 [[package]]
 name = "solana-program-memory"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0268f6c89825fb634a34bd0c3b8fdaeaecfc3728be1d622a8ee6dd577b60d4"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
- "num-traits",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
 ]
 
 [[package]]
 name = "solana-program-option"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc677a2e9bc616eda6dbdab834d463372b92848b2bfe4a1ed4e4b4adba3397d0"
+checksum = "8e7b4ddb464f274deb4a497712664c3b612e3f5f82471d4e47710fc4ab1c3095"
 
 [[package]]
 name = "solana-program-pack"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319f0ef15e6e12dc37c597faccb7d62525a509fec5f6975ecb9419efddeb277b"
+checksum = "c169359de21f6034a63ebf96d6b380980307df17a8d371344ff04a883ec4e9d0"
 dependencies = [
  "solana-program-error",
 ]
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e68cc7ec43ce85bc4074edb0a31019b09f098620dde220bd94ccec5e158b27"
+checksum = "de830498586c69acc46747e241c1e60d9c7aba572d014be3a2c7b1b1306c0304"
 dependencies = [
  "base64 0.22.1",
  "bincode",
- "enum-iterator",
  "itertools 0.12.1",
  "log",
  "percentage",
@@ -3861,77 +3682,97 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-last-restart-slot",
- "solana-log-collector",
- "solana-measure",
- "solana-metrics",
  "solana-program-entrypoint",
  "solana-pubkey",
  "solana-rent",
  "solana-sbpf",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-slot-hashes",
- "solana-stable-layout",
- "solana-svm-callback",
- "solana-svm-feature-set",
- "solana-system-interface",
+ "solana-stake-interface",
+ "solana-svm-callback 3.0.0",
+ "solana-svm-feature-set 3.0.0",
+ "solana-svm-log-collector 3.0.0",
+ "solana-svm-measure 3.0.0",
+ "solana-svm-metrics",
+ "solana-svm-timings 3.0.0",
+ "solana-svm-transaction 3.0.0",
+ "solana-svm-type-overrides 3.0.0",
+ "solana-system-interface 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sysvar",
  "solana-sysvar-id",
- "solana-timings",
- "solana-transaction-context",
- "solana-type-overrides",
- "thiserror 2.0.12",
+ "solana-transaction-context 3.0.0",
+]
+
+[[package]]
+name = "solana-program-runtime"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/agave.git#b676359b1fef681acc0fc97af4b3cf0a080857b7"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "itertools 0.12.1",
+ "log",
+ "percentage",
+ "rand 0.8.5",
+ "serde",
+ "solana-account",
+ "solana-clock",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-structure",
+ "solana-hash",
+ "solana-instruction",
+ "solana-last-restart-slot",
+ "solana-program-entrypoint",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sbpf",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-slot-hashes",
+ "solana-stake-interface",
+ "solana-svm-callback 3.1.0",
+ "solana-svm-feature-set 3.1.0",
+ "solana-svm-log-collector 3.1.0",
+ "solana-svm-measure 3.1.0",
+ "solana-svm-timings 3.1.0",
+ "solana-svm-transaction 3.1.0",
+ "solana-svm-type-overrides 3.1.0",
+ "solana-system-interface 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sysvar",
+ "solana-sysvar-id",
+ "solana-transaction-context 3.1.0",
 ]
 
 [[package]]
 name = "solana-pubkey"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b62adb9c3261a052ca1f999398c388f1daf558a1b492f60a6d9e64857db4ff1"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.7",
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek 4.1.3",
- "five8",
- "five8_const",
- "getrandom 0.2.15",
- "js-sys",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-atomic-u64",
- "solana-decode-error",
- "solana-define-syscall",
- "solana-sanitize",
- "solana-sha256-hasher",
- "wasm-bindgen",
+ "solana-address",
 ]
 
 [[package]]
 name = "solana-rent"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1aea8fdea9de98ca6e8c2da5827707fb3842833521b528a713810ca685d2480"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "serde",
  "serde_derive",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
  "solana-sdk-macro",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-sanitize"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.11.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474a2d95dc819898ded08d24f29642d02189d3e1497bbb442a92a3997b7eb55f"
+checksum = "0f224d906c14efc7ed7f42bc5fe9588f3f09db8cabe7f6023adda62a69678e1a"
 dependencies = [
  "byteorder",
  "combine",
@@ -3940,24 +3781,31 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustc-demangle",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "winapi",
 ]
 
 [[package]]
 name = "solana-sdk-ids"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5d8b9cc68d5c88b062a33e23a6466722467dde0035152d8fb1afbcdf350a5f"
+checksum = "b1b6d6aaf60669c592838d382266b173881c65fb1cdec83b37cb8ce7cb89f9ad"
+dependencies = [
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-sdk-ids"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86280da8b99d03560f6ab5aca9de2e38805681df34e0bb8f238e69b29433b9df"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -3967,67 +3815,49 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-program"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a1caa972414cc78122c32bdae65ac5fe89df7db598585a5cde19d16a20280a"
+checksum = "8efa767b0188f577edae7080e8bf080e5db9458e2b6ee5beaa73e2e6bb54e99d"
 dependencies = [
  "bincode",
  "digest 0.10.7",
- "libsecp256k1",
+ "k256",
  "serde",
  "serde_derive",
  "sha3",
- "solana-feature-set",
  "solana-instruction",
- "solana-precompile-error",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-signature",
 ]
 
 [[package]]
 name = "solana-secp256k1-recover"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa3120b6cdaa270f39444f5093a90a7b03d296d362878f7a6991d6de3bbe496"
+checksum = "394a4470477d66296af5217970a905b1c5569032a7732c367fb69e5666c8607e"
 dependencies = [
- "libsecp256k1",
- "solana-define-syscall",
- "thiserror 2.0.12",
+ "k256",
+ "solana-define-syscall 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "solana-secp256r1-program"
-version = "2.2.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0ae46da3071a900f02d367d99b2f3058fe2e90c5062ac50c4f20cfedad8f0f"
+checksum = "445d8e12592631d76fc4dc57858bae66c9fd7cc838c306c62a472547fc9d0ce6"
 dependencies = [
  "bytemuck",
  "openssl",
- "solana-feature-set",
  "solana-instruction",
- "solana-precompile-error",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-security-txt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
-
-[[package]]
-name = "solana-seed-derivable"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beb82b5adb266c6ea90e5cf3967235644848eac476c5a1f2f9283a143b7c97f"
-dependencies = [
- "solana-derivation-path",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-seed-phrase"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36187af2324f079f65a675ec22b31c24919cb4ac22c79472e85d819db9bbbc15"
+checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -4036,71 +3866,79 @@ dependencies = [
 
 [[package]]
 name = "solana-serde-varint"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc07d00200d82e6def2f7f7a45738e3406b17fe54a18adcf0defa16a97ccadb"
+checksum = "3e5174c57d5ff3c1995f274d17156964664566e2cde18a07bba1586d35a70d3b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "solana-serialize-utils"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817a284b63197d2b27afdba829c5ab34231da4a9b4e763466a003c40ca4f535e"
+checksum = "e7665da4f6e07b58c93ef6aaf9fb6a923fd11b0922ffc53ba74c3cadfa490f26"
 dependencies = [
- "solana-instruction",
+ "solana-instruction-error",
  "solana-pubkey",
  "solana-sanitize",
 ]
 
 [[package]]
 name = "solana-sha256-hasher"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0037386961c0d633421f53560ad7c80675c0447cba4d1bb66d60974dd486c7ea"
+checksum = "a9b912ba6f71cb202c0c3773ec77bf898fa9fe0c78691a2d6859b3b5b8954719"
 dependencies = [
  "sha2 0.10.8",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-hash",
+]
+
+[[package]]
+name = "solana-sha256-hasher"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
+dependencies = [
+ "sha2 0.10.8",
+ "solana-define-syscall 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
  "solana-hash",
 ]
 
 [[package]]
 name = "solana-short-vec"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c54c66f19b9766a56fa0057d060de8378676cb64987533fa088861858fc5a69"
+checksum = "b69d029da5428fc1c57f7d49101b2077c61f049d4112cd5fb8456567cc7d2638"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "solana-shred-version"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd3db0461089d1ad1a78d9ba3f15b563899ca2386351d38428faa5350c60a98"
+checksum = "94953e22ca28fe4541a3447d6baeaf519cc4ddc063253bfa673b721f34c136bb"
 dependencies = [
  "solana-hard-forks",
  "solana-hash",
- "solana-sha256-hasher",
+ "solana-sha256-hasher 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-signature"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d251c8f3dc015f320b4161daac7f108156c837428e5a8cc61136d25beb11d6"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
- "bs58",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
+ "five8",
  "solana-sanitize",
 ]
 
 [[package]]
 name = "solana-signer"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c41991508a4b02f021c1342ba00bcfa098630b213726ceadc7cb032e051975b"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "solana-pubkey",
  "solana-signature",
@@ -4109,35 +3947,33 @@ dependencies = [
 
 [[package]]
 name = "solana-slot-hashes"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8691982114513763e88d04094c9caa0376b867a29577939011331134c301ce"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-hash",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-slot-history"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ccc1b2067ca22754d5283afb2b0126d61eae734fc616d23871b0943b0d935e"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
  "bv",
  "serde",
  "serde_derive",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-stable-layout"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f14f7d02af8f2bc1b5efeeae71bc1c2b7f0f65cd75bcc7d8180f2c762a57f54"
+checksum = "1da74507795b6e8fb60b7c7306c0c36e2c315805d16eaaf479452661234685ac"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
@@ -4145,172 +3981,134 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "1.2.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5269e89fde216b4d7e1d1739cf5303f8398a1ff372a81232abbee80e554a838c"
+checksum = "f6f912ae679b683365348dea482dbd9468d22ff258b554fd36e3d3683c2122e3"
 dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.7",
  "num-traits",
  "serde",
  "serde_derive",
  "solana-clock",
  "solana-cpi",
- "solana-decode-error",
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey",
- "solana-system-interface",
+ "solana-system-interface 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sysvar",
  "solana-sysvar-id",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d841d4bf2f3f7fed557e132ee3b87276ad6852c875bedb2004257a3285071073"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/agave.git#b676359b1fef681acc0fc97af4b3cf0a080857b7"
 dependencies = [
- "agave-feature-set",
+ "agave-feature-set 3.1.0",
  "bincode",
  "log",
  "solana-account",
  "solana-bincode",
  "solana-clock",
- "solana-config-program-client",
+ "solana-config-interface",
  "solana-genesis-config",
  "solana-instruction",
- "solana-log-collector",
  "solana-native-token",
  "solana-packet",
- "solana-program-runtime",
+ "solana-program-runtime 3.1.0",
  "solana-pubkey",
  "solana-rent",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-stake-interface",
+ "solana-svm-log-collector 3.1.0",
+ "solana-svm-type-overrides 3.1.0",
  "solana-sysvar",
- "solana-transaction-context",
- "solana-type-overrides",
+ "solana-transaction-context 3.1.0",
  "solana-vote-interface",
 ]
 
 [[package]]
 name = "solana-svm-callback"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfa93939bf68a7fcce87cc055ca10e5022ea413d0ab68347ac9cf4c2bd4279b"
+checksum = "850b0f7f6397551fbdd0ca55cf1fec6d2943a4e7b1ace7ae2cc4773ccbf4a854"
 dependencies = [
  "solana-account",
+ "solana-clock",
+ "solana-precompile-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-svm-callback"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/agave.git#b676359b1fef681acc0fc97af4b3cf0a080857b7"
+dependencies = [
+ "solana-account",
+ "solana-clock",
  "solana-precompile-error",
  "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "2.3.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c5cf1acee9ce9333f62fea518b641e0454245004def6cb938fd3a182e1526c"
+checksum = "ddf9eb327b0d8a9ee79d6a2d4fbbabee76473cc6f1c862bb1ec8b1e0cb9c1307"
 
 [[package]]
-name = "solana-system-interface"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7c18cb1a91c6be5f5a8ac9276a1d7c737e39a21beba9ea710ab4b9c63bc90"
-dependencies = [
- "js-sys",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-decode-error",
- "solana-instruction",
- "solana-pubkey",
- "wasm-bindgen",
-]
+name = "solana-svm-feature-set"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/agave.git#b676359b1fef681acc0fc97af4b3cf0a080857b7"
 
 [[package]]
-name = "solana-system-program"
-version = "2.3.1"
+name = "solana-svm-log-collector"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e737e67d327b8260306522fde5758a1b09af5e6cd630d589c25e610f74a0c6a8"
+checksum = "653640ff91ff2724219e8ec3c599663307d1ece7ff699ffc0342503d09f4bb9f"
 dependencies = [
- "bincode",
  "log",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-bincode",
- "solana-fee-calculator",
- "solana-instruction",
- "solana-log-collector",
- "solana-nonce",
- "solana-nonce-account",
- "solana-packet",
- "solana-program-runtime",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
- "solana-sysvar",
- "solana-transaction-context",
- "solana-type-overrides",
 ]
 
 [[package]]
-name = "solana-sysvar"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50c92bc019c590f5e42c61939676e18d14809ed00b2a59695dd5c67ae72c097"
+name = "solana-svm-log-collector"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/agave.git#b676359b1fef681acc0fc97af4b3cf0a080857b7"
 dependencies = [
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "lazy_static",
- "serde",
- "serde_derive",
- "solana-account-info",
- "solana-clock",
- "solana-define-syscall",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-last-restart-slot",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stake-interface",
- "solana-sysvar-id",
+ "log",
 ]
 
 [[package]]
-name = "solana-sysvar-id"
-version = "2.2.1"
+name = "solana-svm-measure"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5762b273d3325b047cfda250787f8d796d781746860d5d0a746ee29f3e8812c1"
+checksum = "a7602d9a00074a418c8dae0024e4e213b68f44fb7e7aca3cc65bc99cb9145bd8"
+
+[[package]]
+name = "solana-svm-measure"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/agave.git#b676359b1fef681acc0fc97af4b3cf0a080857b7"
+
+[[package]]
+name = "solana-svm-metrics"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f5361758f7f46a12386741f44a2a36027e5b9e697e503eeeabb5be41ab321c"
 dependencies = [
- "solana-pubkey",
- "solana-sdk-ids",
+ "crossbeam-channel",
+ "gethostname",
+ "log",
+ "reqwest",
+ "solana-cluster-type",
+ "solana-sha256-hasher 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-time-utils",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
-name = "solana-time-utils"
-version = "2.2.1"
+name = "solana-svm-timings"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
-
-[[package]]
-name = "solana-timings"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda43b3a20f03b5cc0bb235861b53debcf01885de214dd77087c4d349e571bd6"
+checksum = "a055b583748c41721d1ef87c6da051522da139afa6b5881aa9d04632466adb13"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -4318,10 +4116,199 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-transaction-context"
-version = "2.3.1"
+name = "solana-svm-timings"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/agave.git#b676359b1fef681acc0fc97af4b3cf0a080857b7"
+dependencies = [
+ "eager",
+ "enum-iterator",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-svm-transaction"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48a900e43746e45fb0ae279b89b24bd527c35411e483413a1dd39339cea7177a"
+checksum = "c8bb3c2b194607512925e834bce30e060e179634a5c70a5971e868a754c7c31a"
+dependencies = [
+ "solana-hash",
+ "solana-message",
+ "solana-pubkey",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-signature",
+ "solana-transaction",
+]
+
+[[package]]
+name = "solana-svm-transaction"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/agave.git#b676359b1fef681acc0fc97af4b3cf0a080857b7"
+dependencies = [
+ "solana-hash",
+ "solana-message",
+ "solana-pubkey",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-signature",
+ "solana-transaction",
+]
+
+[[package]]
+name = "solana-svm-type-overrides"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7a6aa721d9596fe33ddf907da38713d10fc2773b17794f3654159e1646b770"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "solana-svm-type-overrides"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/agave.git#b676359b1fef681acc0fc97af4b3cf0a080857b7"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1790547bfc3061f1ee68ea9d8dc6c973c02a163697b24263a8e9f2e6d4afa2"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-instruction",
+ "solana-msg 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "2.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-instruction",
+ "solana-msg 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
+ "solana-program-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-system-program"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed56fee950fd98d7e5187d3d51e4a630c156aafc4fa0527090635bb33d08f9ff"
+dependencies = [
+ "bincode",
+ "log",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-bincode",
+ "solana-fee-calculator 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-instruction",
+ "solana-nonce",
+ "solana-nonce-account",
+ "solana-packet",
+ "solana-program-runtime 3.0.0",
+ "solana-pubkey",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-svm-log-collector 3.0.0",
+ "solana-svm-type-overrides 3.0.0",
+ "solana-system-interface 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sysvar",
+ "solana-transaction-context 3.0.0",
+]
+
+[[package]]
+name = "solana-sysvar"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-account-info",
+ "solana-clock",
+ "solana-define-syscall 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-calculator 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
+ "solana-hash",
+ "solana-instruction",
+ "solana-last-restart-slot",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
+ "solana-sdk-macro",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-sysvar-id"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
+dependencies = [
+ "solana-pubkey",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
+]
+
+[[package]]
+name = "solana-time-utils"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
+
+[[package]]
+name = "solana-transaction"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
+dependencies = [
+ "solana-hash",
+ "solana-instruction",
+ "solana-message",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sdk-ids 3.0.0 (git+https://github.com/anza-xyz/solana-sdk.git)",
+ "solana-signature",
+ "solana-transaction-error",
+]
+
+[[package]]
+name = "solana-transaction-context"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de80299b069929cfd14aabc606605867810dc4c1a57fb488a8c84a1273e545d"
+dependencies = [
+ "bincode",
+ "qualifier_attr",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sbpf",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-transaction-context"
+version = "3.1.0"
+source = "git+https://github.com/anza-xyz/agave.git#b676359b1fef681acc0fc97af4b3cf0a080857b7"
 dependencies = [
  "bincode",
  "serde",
@@ -4331,87 +4318,43 @@ dependencies = [
  "solana-instructions-sysvar",
  "solana-pubkey",
  "solana-rent",
- "solana-sdk-ids",
+ "solana-sbpf",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-transaction-error"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a9dc8fdb61c6088baab34fc3a8b8473a03a7a5fd404ed8dd502fa79b67cb1"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
 dependencies = [
- "solana-instruction",
+ "solana-instruction-error",
  "solana-sanitize",
 ]
 
 [[package]]
-name = "solana-type-overrides"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33dcab747a0c14e7eeb8b0f2fbf4f9c6879ee88040cddd4c35cce2d94d751bcb"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "solana-vote-interface"
-version = "2.2.5"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f08746f154458f28b98330c0d55cb431e2de64ee4b8efc98dcbe292e0672b"
+checksum = "66631ddbe889dab5ec663294648cd1df395ec9df7a4476e7b3e095604cfdb539"
 dependencies = [
  "bincode",
+ "cfg_eval",
  "num-derive",
  "num-traits",
  "serde",
  "serde_derive",
+ "serde_with",
  "solana-clock",
- "solana-decode-error",
  "solana-hash",
  "solana-instruction",
+ "solana-instruction-error",
  "solana-pubkey",
  "solana-rent",
- "solana-sdk-ids",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-serde-varint",
  "solana-serialize-utils",
  "solana-short-vec",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-zk-sdk"
-version = "2.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70bffb28540a216443ba302ab017d18a0e03f5300772929db79608870ee1c6e"
-dependencies = [
- "aes-gcm-siv",
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek 4.1.3",
- "itertools 0.12.1",
- "js-sys",
- "lazy_static",
- "merlin",
- "num-derive",
- "num-traits",
- "rand 0.8.5",
- "serde",
- "serde_derive",
- "serde_json",
- "sha3",
- "solana-derivation-path",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-seed-derivable",
- "solana-seed-phrase",
- "solana-signature",
- "solana-signer",
- "subtle",
- "thiserror 2.0.12",
- "wasm-bindgen",
- "zeroize",
+ "solana-system-interface 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4421,369 +4364,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "spl-associated-token-account"
-version = "7.0.0"
+name = "spki"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae179d4a26b3c7a20c839898e6aed84cb4477adf108a366c95532f058aea041b"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
- "borsh 1.5.7",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-associated-token-account-client",
- "spl-token",
- "spl-token-2022",
- "thiserror 2.0.12",
+ "base64ct",
+ "der",
 ]
 
 [[package]]
-name = "spl-associated-token-account-client"
+name = "spl-associated-token-account-interface"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f8349dbcbe575f354f9a533a21f272f3eb3808a49e2fdc1c34393b88ba76cb"
+checksum = "e6433917b60441d68d99a17e121d9db0ea15a9a69c0e5afa34649cf5ba12612f"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
 ]
 
 [[package]]
-name = "spl-discriminator"
-version = "0.4.1"
+name = "spl-token-interface"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7398da23554a31660f17718164e31d31900956054f54f52d5ec1be51cb4f4b3"
-dependencies = [
- "bytemuck",
- "solana-program-error",
- "solana-sha256-hasher",
- "spl-discriminator-derive",
-]
-
-[[package]]
-name = "spl-discriminator-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
-dependencies = [
- "quote",
- "spl-discriminator-syn",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "spl-discriminator-syn"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f05593b7ca9eac7caca309720f2eafb96355e037e6d373b909a80fe7b69b9"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
- "syn 2.0.87",
- "thiserror 1.0.68",
-]
-
-[[package]]
-name = "spl-elgamal-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65edfeed09cd4231e595616aa96022214f9c9d2be02dea62c2b30d5695a6833a"
-dependencies = [
- "bytemuck",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-system-interface",
- "solana-sysvar",
- "solana-zk-sdk",
- "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
-]
-
-[[package]]
-name = "spl-memo"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f09647c0974e33366efeb83b8e2daebb329f0420149e74d3a4bd2c08cf9f7cb"
-dependencies = [
- "solana-account-info",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey",
-]
-
-[[package]]
-name = "spl-pod"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d994afaf86b779104b4a95ba9ca75b8ced3fdb17ee934e38cb69e72afbe17799"
-dependencies = [
- "borsh 1.5.7",
- "bytemuck",
- "bytemuck_derive",
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
- "solana-program-option",
- "solana-pubkey",
- "solana-zk-sdk",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-program-error"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdebc8b42553070b75aa5106f071fef2eb798c64a7ec63375da4b1f058688c6"
-dependencies = [
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
- "spl-program-error-derive",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-program-error-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2539e259c66910d78593475540e8072f0b10f0f61d7607bbf7593899ed52d0"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2 0.10.8",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1408e961215688715d5a1063cbdcf982de225c45f99c82b4f7d7e1dd22b998d7"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053067c6a82c705004f91dae058b11b4780407e9ccd6799dc9e7d0fab5f242da"
+checksum = "8c564ac05a7c8d8b12e988a37d82695b5ba4db376d07ea98bc4882c81f96c7f3"
 dependencies = [
  "arrayref",
  "bytemuck",
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-account-info",
- "solana-cpi",
- "solana-decode-error",
  "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
  "solana-program-error",
- "solana-program-memory",
  "solana-program-option",
  "solana-program-pack",
  "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-sysvar",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-2022"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f0dfbb079eebaee55e793e92ca5f433744f4b71ee04880bfd6beefba5973e5"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-account-info",
- "solana-clock",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-native-token",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-security-txt",
- "solana-system-interface",
- "solana-sysvar",
- "solana-zk-sdk",
- "spl-elgamal-registry",
- "spl-memo",
- "spl-pod",
- "spl-token",
- "spl-token-confidential-transfer-ciphertext-arithmetic",
- "spl-token-confidential-transfer-proof-extraction",
- "spl-token-confidential-transfer-proof-generation",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
- "spl-type-length-value",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-ciphertext-arithmetic"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ab20faf7b5edaa79acd240e0f21d5a2ef936aa99ed98f698573a2825b299c4"
-dependencies = [
- "base64 0.22.1",
- "bytemuck",
- "solana-curve25519",
- "solana-zk-sdk",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2629860ff04c17bafa9ba4bed8850a404ecac81074113e1f840dbd0ebb7bd6"
-dependencies = [
- "bytemuck",
- "solana-account-info",
- "solana-curve25519",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-zk-sdk",
- "spl-pod",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-generation"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5b124840d4aed474cef101d946a798b806b46a509ee4df91021e1ab1cef3ef"
-dependencies = [
- "curve25519-dalek 4.1.3",
- "solana-zk-sdk",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-group-interface"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5597b4cd76f85ce7cd206045b7dc22da8c25516573d42d267c8d1fd128db5129"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-metadata-interface"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "304d6e06f0de0c13a621464b1fd5d4b1bebf60d15ca71a44d3839958e0da16ee"
-dependencies = [
- "borsh 1.5.7",
- "num-derive",
- "num-traits",
- "solana-borsh",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-type-length-value",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e905b849b6aba63bde8c4badac944ebb6c8e6e14817029cbe1bc16829133bd"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution",
- "spl-type-length-value",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-type-length-value"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d417eb548214fa822d93f84444024b4e57c13ed6719d4dcc68eec24fb481e9f5"
-dependencies = [
- "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
- "spl-discriminator",
- "spl-pod",
- "thiserror 2.0.12",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -4843,15 +4460,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "test-program-cpi-target"
 version = "0.1.0"
 dependencies = [
@@ -4891,8 +4499,8 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
+ "solana-sdk-ids 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-system-interface 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4906,11 +4514,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -4926,9 +4534,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5010,15 +4618,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -5142,16 +4741,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "unreachable"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5171,16 +4760,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "uriparse"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
-dependencies = [
- "fnv",
- "lazy_static",
-]
 
 [[package]]
 name = "url"
@@ -5547,3 +5126,13 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[patch.unused]]
+name = "solana-sdk"
+version = "3.0.0"
+source = "git+https://github.com/anza-xyz/solana-sdk.git#6809dde2e6bec1506dfe7c213c8c865c231b717e"
+
+[[patch.unused]]
+name = "spl-associated-token-account"
+version = "7.0.0"
+source = "git+https://github.com/solana-program/associated-token-account.git#209714777d7113af98e6e0ca4a3a0f26ffb9e8fe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,9 @@ edition = "2021"
 version = "0.5.1"
 
 [workspace.dependencies]
-agave-feature-set = "2.3"
-agave-precompiles = "2.3"
+agave-feature-set = "3.0"
+agave-precompiles = "3.0"
+agave-syscalls = "3.0.0"
 bincode = "1.3.3"
 bs58 = "0.5.1"
 chrono = "0.4.38"
@@ -52,44 +53,89 @@ serde = "1.0.203"
 serde_json = "1.0.117"
 serde_yaml = "0.9.34"
 serial_test = "2.0"
-solana-account = "2.2"
-solana-account-info = "2.2"
-solana-bpf-loader-program = "2.3"
-solana-clock = "2.2"
-solana-compute-budget = "2.3"
-solana-cpi = "2.2"
-solana-ed25519-program = "2.2"
-solana-epoch-rewards = "2.2"
-solana-epoch-schedule = "2.2"
-solana-hash = "2.2"
-solana-instruction = "2.2"
-solana-keccak-hasher = "2.2"
-solana-loader-v3-interface = "3.0"
-solana-loader-v4-interface = "2.2"
-solana-log-collector = "2.3"
-solana-logger = "2.3"
-solana-native-token = "2.2"
-solana-precompile-error = "2.2"
-solana-program-entrypoint = "2.2"
-solana-program-error = "2.2"
-solana-program-runtime = "2.3"
-solana-pubkey = "2.2"
-solana-rent = "2.2"
-solana-sdk-ids = "2.2"
-solana-secp256k1-program = "2.2"
-solana-secp256r1-program = "2.2"
-solana-slot-hashes = "2.2"
-solana-stake-interface = "1.0"
-solana-stake-program = "2.3"
-solana-svm-callback = "2.3"
-solana-system-interface = "1.0"
-solana-system-program = "2.3"
-solana-sysvar = "2.2"
-solana-sysvar-id = "2.2"
-solana-timings = "2.3"
-solana-transaction-context = "2.3"
-spl-associated-token-account = "7.0.0"
-spl-token = "8.0.0"
+solana-account = "3.0"
+solana-account-info = "3.0"
+solana-bpf-loader-program = "3.0"
+solana-clock = "3.0"
+solana-compute-budget = "3.0"
+solana-cpi = "3.0"
+solana-ed25519-program = "3.0"
+solana-epoch-rewards = "3.0"
+solana-epoch-schedule = "3.0"
+solana-hash = "3.0"
+solana-instruction = "3.0"
+solana-instruction-error = { version = "2.0", features = ["serde"] }
+solana-keccak-hasher = "3.0"
+solana-loader-v3-interface = "6.1.0"
+solana-loader-v4-interface = "3.1.0"
+solana-logger = "3.0"
+solana-native-token = "3.0"
+solana-precompile-error = "3.0"
+solana-program-entrypoint = "3.0"
+solana-program-error = "3.0"
+solana-program-pack = "3.0"
+solana-program-runtime = "3.0"
+solana-pubkey = "3.0"
+solana-rent = "3.0"
+solana-sdk-ids = "3.0"
+solana-secp256k1-program = "3.0"
+solana-secp256r1-program = "3.0"
+solana-sha256-hasher = { version = "3.0", features = ["sha2"] }
+solana-slot-hashes = "3.0"
+solana-stake-interface = "2.0"
+solana-stake-program = "3.0"
+solana-svm-callback = "3.0"
+solana-svm-log-collector = "3.0"
+solana-svm-timings = "3.0"
+solana-system-interface = "2.0"
+solana-system-program = "3.0"
+solana-sysvar = "3.0"
+solana-sysvar-id = "3.0"
+solana-timings = "3.0"
+solana-transaction-context = "3.0"
+spl-associated-token-account-interface = "2.0.0"
+spl-token-interface = "2.0.0"
 thiserror = "1.0.64"
 tokio = "1.37.0"
 which = "=4.4.0"
+
+
+# Unfortunately we still need a number of patches until updated SPL crates are all published
+[patch.crates-io]
+solana-address = { version = "1.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-pubkey = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-sdk = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-program-entrypoint = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-program-error = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+# solana-program-runtime = { version = "=3.0.0", git = "https://github.com/anza-xyz/agave.git" }
+solana-sysvar = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-sysvar-id = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-account = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-account-info = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-instruction = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-message = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-instruction-error = { version = "2.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-transaction-context = { version = "3.0", git = "https://github.com/anza-xyz/agave.git" }
+solana-transaction-error = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-signer = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-nonce = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-bincode = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-transaction     = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-sanitize        = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-hash            = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-nonce-account   = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-signature = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-rent = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-slot-hashes = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-epoch-schedule = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-epoch-rewards = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-clock = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-last-restart-slot = { version = "3.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+# solana-compute-budget = { version = "3.0", git = "https://github.com/anza-xyz/agave.git" }
+solana-svm-timings = { version = "3.0", git = "https://github.com/anza-xyz/agave.git" }
+solana-svm-callback = { version = "3.0", git = "https://github.com/anza-xyz/agave.git" }
+# solana-bpf-loader-program = { version = "3.0", git = "https://github.com/anza-xyz/agave.git" }
+solana-loader-v3-interface = { version = "6.1.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-loader-v4-interface = { version = "3.1.0", git = "https://github.com/anza-xyz/solana-sdk.git" }
+solana-stake-program = { version = "3.0", git = "https://github.com/anza-xyz/agave.git" }
+spl-associated-token-account = { version = "7.0.0", git = "https://github.com/solana-program/associated-token-account.git" }

--- a/fuzz/fixture-fd/src/context.rs
+++ b/fuzz/fixture-fd/src/context.rs
@@ -54,7 +54,7 @@ impl From<EpochContext> for ProtoEpochContext {
 }
 
 /// Instruction context fixture.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default)]
 pub struct Context {
     /// The program ID of the program being invoked.
     pub program_id: Pubkey,

--- a/fuzz/fixture-fd/src/instr_account.rs
+++ b/fuzz/fixture-fd/src/instr_account.rs
@@ -12,28 +12,16 @@ impl From<ProtoInstrAccount> for InstructionAccount {
             is_writable,
             is_signer,
         } = value;
-        Self {
-            index_in_transaction: index as u16,
-            index_in_caller: index as u16,
-            index_in_callee: index as u16,
-            is_signer,
-            is_writable,
-        }
+        Self::new(index as u16, is_signer, is_writable)
     }
 }
 
 impl From<InstructionAccount> for ProtoInstrAccount {
     fn from(value: InstructionAccount) -> Self {
-        let InstructionAccount {
-            index_in_transaction,
-            is_signer,
-            is_writable,
-            ..
-        } = value;
         Self {
-            index: index_in_transaction as u32,
-            is_signer,
-            is_writable,
+            index: value.index_in_transaction as u32,
+            is_signer: value.is_signer(),
+            is_writable: value.is_writable(),
         }
     }
 }

--- a/fuzz/fixture-fd/src/lib.rs
+++ b/fuzz/fixture-fd/src/lib.rs
@@ -29,7 +29,7 @@ use {
 
 /// A fixture for invoking a single instruction against a simulated SVM
 /// program runtime environment, for a given program.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default)]
 pub struct Fixture {
     /// The fixture metadata.
     pub metadata: Option<Metadata>,
@@ -154,13 +154,7 @@ mod tests {
         let instruction_accounts = accounts
             .iter()
             .enumerate()
-            .map(|(i, _)| InstructionAccount {
-                index_in_transaction: i as u16,
-                index_in_caller: i as u16,
-                index_in_callee: i as u16,
-                is_signer: false,
-                is_writable: true,
-            })
+            .map(|(i, _)| InstructionAccount::new(i as u16, false, true))
             .collect::<Vec<_>>();
         let instruction_data = vec![4; 24];
         let slot_context = SlotContext { slot: 42 };

--- a/fuzz/fixture/proto/compute_budget.proto
+++ b/fuzz/fixture/proto/compute_budget.proto
@@ -15,7 +15,6 @@ message ComputeBudget {
     uint64 max_call_depth = 10;
     uint64 stack_frame_size = 11;
     uint64 log_pubkey_units = 12;
-    uint64 max_cpi_instruction_size = 13;
     uint64 cpi_bytes_per_unit = 14;
     uint64 sysvar_base_cost = 15;
     uint64 secp256k1_recover_cost = 16;

--- a/fuzz/fixture/src/compute_budget.rs
+++ b/fuzz/fixture/src/compute_budget.rs
@@ -20,7 +20,6 @@ impl From<ProtoComputeBudget> for ComputeBudget {
             max_call_depth,
             stack_frame_size,
             log_pubkey_units,
-            max_cpi_instruction_size,
             cpi_bytes_per_unit,
             sysvar_base_cost,
             secp256k1_recover_cost,
@@ -68,7 +67,6 @@ impl From<ProtoComputeBudget> for ComputeBudget {
             max_call_depth: max_call_depth as usize,
             stack_frame_size: stack_frame_size as usize,
             log_pubkey_units,
-            max_cpi_instruction_size: max_cpi_instruction_size as usize,
             cpi_bytes_per_unit,
             sysvar_base_cost,
             secp256k1_recover_cost,
@@ -120,7 +118,6 @@ impl From<ComputeBudget> for ProtoComputeBudget {
             max_call_depth,
             stack_frame_size,
             log_pubkey_units,
-            max_cpi_instruction_size,
             cpi_bytes_per_unit,
             sysvar_base_cost,
             secp256k1_recover_cost,
@@ -168,7 +165,6 @@ impl From<ComputeBudget> for ProtoComputeBudget {
             max_call_depth: max_call_depth as u64,
             stack_frame_size: stack_frame_size as u64,
             log_pubkey_units,
-            max_cpi_instruction_size: max_cpi_instruction_size as u64,
             cpi_bytes_per_unit,
             sysvar_base_cost,
             secp256k1_recover_cost,
@@ -218,7 +214,6 @@ pub(crate) fn hash_proto_compute_budget(hasher: &mut Hasher, compute_budget: &Pr
     hasher.hash(&compute_budget.max_call_depth.to_le_bytes());
     hasher.hash(&compute_budget.stack_frame_size.to_le_bytes());
     hasher.hash(&compute_budget.log_pubkey_units.to_le_bytes());
-    hasher.hash(&compute_budget.max_cpi_instruction_size.to_le_bytes());
     hasher.hash(&compute_budget.cpi_bytes_per_unit.to_le_bytes());
     hasher.hash(&compute_budget.sysvar_base_cost.to_le_bytes());
     hasher.hash(&compute_budget.secp256k1_recover_cost.to_le_bytes());

--- a/fuzz/fixture/src/context.rs
+++ b/fuzz/fixture/src/context.rs
@@ -14,7 +14,7 @@ use {
 };
 
 /// Instruction context fixture.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Context {
     /// The compute budget to use for the simulation.
     pub compute_budget: ComputeBudget,
@@ -30,6 +30,20 @@ pub struct Context {
     pub instruction_data: Vec<u8>,
     /// Input accounts with state.
     pub accounts: Vec<(Pubkey, Account)>,
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self {
+            compute_budget: ComputeBudget::new_with_defaults(true),
+            feature_set: FeatureSet::default(),
+            sysvars: Sysvars::default(),
+            program_id: Pubkey::default(),
+            instruction_accounts: Vec::default(),
+            instruction_data: Vec::default(),
+            accounts: Vec::default(),
+        }
+    }
 }
 
 impl From<ProtoContext> for Context {
@@ -64,7 +78,10 @@ impl From<ProtoContext> for Context {
             .collect();
 
         Self {
-            compute_budget: value.compute_budget.map(Into::into).unwrap_or_default(),
+            compute_budget: value
+                .compute_budget
+                .map(Into::into)
+                .unwrap_or_else(|| ComputeBudget::new_with_defaults(true)),
             feature_set: value.feature_set.map(Into::into).unwrap_or_default(),
             sysvars: value.sysvars.map(Into::into).unwrap_or_default(),
             program_id,

--- a/fuzz/fixture/src/lib.rs
+++ b/fuzz/fixture/src/lib.rs
@@ -112,7 +112,7 @@ mod tests {
     fn test_consistent_hashing() {
         const ITERATIONS: usize = 1000;
 
-        let compute_budget = ComputeBudget::default();
+        let compute_budget = ComputeBudget::new_with_defaults(true);
         let feature_set = FeatureSet::all_enabled();
         let sysvars = Sysvars::default();
         let program_id = Pubkey::default();

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -10,7 +10,7 @@ edition = { workspace = true }
 version = { workspace = true }
 
 [features]
-default = []
+default = ["serde"]
 all-builtins = [
     "dep:solana-stake-program",
 ]
@@ -32,6 +32,7 @@ invocation-inspect-callback = []
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-precompiles = { workspace = true }
+agave-syscalls = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 mollusk-svm-error = { workspace = true }
@@ -48,9 +49,9 @@ solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
+solana-instruction-error = { workspace = true, features = ["serde"] }
 solana-loader-v3-interface = { workspace = true, features = ["serde"] }
 solana-loader-v4-interface = { workspace = true }
-solana-log-collector = { workspace = true }
 solana-logger = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-program-error = { workspace = true }
@@ -58,14 +59,16 @@ solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
+solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-slot-hashes = { workspace = true }
 solana-stake-interface = { workspace = true }
 solana-stake-program = { workspace = true, optional = true }
 solana-svm-callback = { workspace = true }
+solana-svm-log-collector = { workspace = true }
+solana-svm-timings = { workspace = true }
 solana-system-program = { workspace = true }
 solana-sysvar = { workspace = true }
 solana-sysvar-id = { workspace = true }
-solana-timings = { workspace = true }
 solana-transaction-context = { workspace = true, features = ["dev-context-only-utils"] }
 
 [dev-dependencies]

--- a/harness/src/fuzz/firedancer.rs
+++ b/harness/src/fuzz/firedancer.rs
@@ -114,7 +114,7 @@ pub(crate) fn parse_fixture_context(context: &FuzzContext) -> ParsedFixtureConte
 
     let compute_budget = ComputeBudget {
         compute_unit_limit: *compute_units_available,
-        ..Default::default()
+        ..ComputeBudget::new_with_defaults(true)
     };
 
     let accounts = accounts
@@ -126,13 +126,13 @@ pub(crate) fn parse_fixture_context(context: &FuzzContext) -> ParsedFixtureConte
         .iter()
         .map(|ia| {
             let pubkey = accounts
-                .get(ia.index_in_caller as usize)
+                .get(ia.index_in_transaction as usize)
                 .expect("Index out of bounds")
                 .0;
             AccountMeta {
                 pubkey,
-                is_signer: ia.is_signer,
-                is_writable: ia.is_writable,
+                is_signer: ia.is_signer(),
+                is_writable: ia.is_writable(),
             }
         })
         .collect::<Vec<_>>();

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -466,12 +466,12 @@ use {
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_hash::Hash,
     solana_instruction::{AccountMeta, Instruction},
-    solana_log_collector::LogCollector,
     solana_precompile_error::PrecompileError,
     solana_program_runtime::invoke_context::{EnvironmentConfig, InvokeContext},
     solana_pubkey::Pubkey,
     solana_svm_callback::InvokeContextCallback,
-    solana_timings::ExecuteTimings,
+    solana_svm_log_collector::LogCollector,
+    solana_svm_timings::ExecuteTimings,
     solana_transaction_context::TransactionContext,
     std::{cell::RefCell, collections::HashSet, iter::once, rc::Rc},
 };
@@ -538,7 +538,7 @@ impl Default for Mollusk {
              solana_runtime::message_processor=debug,\
              solana_runtime::system_instruction_processor=trace",
         );
-        let compute_budget = ComputeBudget::default();
+        let compute_budget = ComputeBudget::new_with_defaults(true);
         #[cfg(feature = "fuzz")]
         let feature_set = {
             // Omit "test features" (they have the same u64 ID).
@@ -716,6 +716,16 @@ impl Mollusk {
                 self.compute_budget.to_cost(),
             );
 
+            // Configure the next instruction frame for this invocation.
+            invoke_context
+                .transaction_context
+                .configure_next_instruction_for_tests(
+                    program_id_index,
+                    instruction_accounts.clone(),
+                    &instruction.data,
+                )
+                .expect("failed to configure next instruction");
+
             #[cfg(feature = "invocation-inspect-callback")]
             self.invocation_inspect_callback.before_invocation(
                 &instruction.program_id,
@@ -728,18 +738,10 @@ impl Mollusk {
                 invoke_context.process_precompile(
                     &instruction.program_id,
                     &instruction.data,
-                    &instruction_accounts,
-                    &[program_id_index],
                     std::iter::once(instruction.data.as_ref()),
                 )
             } else {
-                invoke_context.process_instruction(
-                    &instruction.data,
-                    &instruction_accounts,
-                    &[program_id_index],
-                    &mut compute_units_consumed,
-                    &mut timings,
-                )
+                invoke_context.process_instruction(&mut compute_units_consumed, &mut timings)
             };
 
             #[cfg(feature = "invocation-inspect-callback")]
@@ -759,9 +761,9 @@ impl Mollusk {
                         .find_index_of_account(pubkey)
                         .map(|index| {
                             let resulting_account = transaction_context
-                                .get_account_at_index(index)
+                                .accounts()
+                                .try_borrow(index)
                                 .unwrap()
-                                .borrow()
                                 .clone()
                                 .into();
                             (*pubkey, resulting_account)

--- a/harness/src/program.rs
+++ b/harness/src/program.rs
@@ -2,8 +2,8 @@
 
 use {
     agave_feature_set::FeatureSet,
+    agave_syscalls::create_program_runtime_environment_v1,
     solana_account::Account,
-    solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_loader_v4_interface::state::{LoaderV4State, LoaderV4Status},

--- a/harness/src/sysvar.rs
+++ b/harness/src/sysvar.rs
@@ -58,7 +58,10 @@ impl Default for Sysvars {
 }
 
 impl Sysvars {
-    fn sysvar_account<T: SysvarId + Sysvar>(&self, sysvar: &T) -> (Pubkey, Account) {
+    fn sysvar_account<T: SysvarId + Sysvar + serde::Serialize>(
+        &self,
+        sysvar: &T,
+    ) -> (Pubkey, Account) {
         let data = bincode::serialize::<T>(sysvar).unwrap();
         let space = data.len();
         let lamports = self.rent.minimum_balance(space);

--- a/harness/tests/account_store.rs
+++ b/harness/tests/account_store.rs
@@ -33,30 +33,9 @@ fn test_transfer_with_context() {
 
     let context = mollusk.with_context(account_store);
 
-    // Build and debug-print the transfer instruction
-    let instr =
-        solana_system_interface::instruction::transfer(&sender, &recipient, transfer_amount);
-    eprintln!(
-        "[test debug] system transfer data_len: {}, data: {:?}",
-        instr.data.len(),
-        instr.data
-    );
-    match bincode::deserialize::<solana_system_interface::instruction::SystemInstruction>(
-        &instr.data,
-    ) {
-        Ok(decoded) => eprintln!("[test debug] decode ok: {:?}", decoded),
-        Err(err) => eprintln!("[test debug] decode err: {}", err),
-    }
-    for (i, meta) in instr.accounts.iter().enumerate() {
-        eprintln!(
-            "[test debug] meta[{}]: pubkey={}, signer={}, writable={}",
-            i, meta.pubkey, meta.is_signer, meta.is_writable
-        );
-    }
-
     // Process the transfer instruction
     let result = context.process_and_validate_instruction(
-        &instr,
+        &solana_system_interface::instruction::transfer(&sender, &recipient, transfer_amount),
         &[
             Check::success(),
             Check::compute_units(DEFAULT_COMPUTE_UNITS),
@@ -114,37 +93,15 @@ fn test_multiple_transfers_with_persistent_state() {
         Check::compute_units(DEFAULT_COMPUTE_UNITS),
     ];
 
-    // First transfer: Alice -> Bob (with debug)
+    // First transfer: Alice -> Bob
     let instruction1 =
         solana_system_interface::instruction::transfer(&alice, &bob, transfer1_amount);
-    eprintln!(
-        "[test debug] ix1 data_len: {}, data: {:?}",
-        instruction1.data.len(),
-        instruction1.data
-    );
-    match bincode::deserialize::<solana_system_interface::instruction::SystemInstruction>(
-        &instruction1.data,
-    ) {
-        Ok(decoded) => eprintln!("[test debug] ix1 decode ok: {:?}", decoded),
-        Err(err) => eprintln!("[test debug] ix1 decode err: {}", err),
-    }
     let result1 = context.process_and_validate_instruction(&instruction1, &checks);
     assert!(!result1.program_result.is_err());
 
-    // Second transfer: Bob -> Charlie (with debug)
+    // Second transfer: Bob -> Charlie
     let instruction2 =
         solana_system_interface::instruction::transfer(&bob, &charlie, transfer2_amount);
-    eprintln!(
-        "[test debug] ix2 data_len: {}, data: {:?}",
-        instruction2.data.len(),
-        instruction2.data
-    );
-    match bincode::deserialize::<solana_system_interface::instruction::SystemInstruction>(
-        &instruction2.data,
-    ) {
-        Ok(decoded) => eprintln!("[test debug] ix2 decode ok: {:?}", decoded),
-        Err(err) => eprintln!("[test debug] ix2 decode err: {}", err),
-    }
     let result2 = context.process_and_validate_instruction(&instruction2, &checks);
     assert!(!result2.program_result.is_err());
 
@@ -251,17 +208,6 @@ fn test_account_store_default_account() {
     // Try to transfer from a non-existent account (should get default account)
     let instruction =
         solana_system_interface::instruction::transfer(&non_existent_key, &recipient, 1000);
-    eprintln!(
-        "[test debug] default-account transfer data_len: {}, data: {:?}",
-        instruction.data.len(),
-        instruction.data
-    );
-    match bincode::deserialize::<solana_system_interface::instruction::SystemInstruction>(
-        &instruction.data,
-    ) {
-        Ok(decoded) => eprintln!("[test debug] default decode ok: {:?}", decoded),
-        Err(err) => eprintln!("[test debug] default decode err: {}", err),
-    }
 
     // This should fail because the default account has 0 lamports
     context.process_and_validate_instruction(

--- a/harness/tests/bpf_program.rs
+++ b/harness/tests/bpf_program.rs
@@ -67,7 +67,7 @@ fn test_write_data() {
         &[(key, account.clone())],
         &[
             Check::success(),
-            Check::compute_units(367),
+            Check::compute_units(384),
             Check::account(&key)
                 .data(data)
                 .lamports(lamports)
@@ -152,7 +152,7 @@ fn test_transfer() {
         ],
         &[
             Check::success(),
-            Check::compute_units(2481),
+            Check::compute_units(2533),
             Check::account(&payer)
                 .lamports(payer_lamports - transfer_amount)
                 .build(),
@@ -256,7 +256,7 @@ fn test_close_account() {
         ],
         &[
             Check::success(),
-            Check::compute_units(2554),
+            Check::compute_units(2608),
             Check::account(&key)
                 .closed() // The rest is unnecessary, just testing.
                 .data(&[])
@@ -376,7 +376,7 @@ fn test_cpi() {
         ],
         &[
             Check::success(),
-            Check::compute_units(2347),
+            Check::compute_units(2418),
             Check::account(&key)
                 .data(data)
                 .lamports(lamports)

--- a/harness/tests/fd_test_vectors.rs
+++ b/harness/tests/fd_test_vectors.rs
@@ -152,12 +152,19 @@ fn compare_instruction_accounts(a: &[InstructionAccount], b: &[InstructionAccoun
     let mut a_sorted = a.to_vec();
     let mut b_sorted = b.to_vec();
 
-    // Sort by Pubkey
+    // Sort by index_in_transaction
     a_sorted.sort_by(|ia_a, ia_b| ia_a.index_in_transaction.cmp(&ia_b.index_in_transaction));
     b_sorted.sort_by(|ia_a, ia_b| ia_a.index_in_transaction.cmp(&ia_b.index_in_transaction));
 
-    // Compare sorted lists
-    a_sorted == b_sorted
+    // Compare sorted lists; InstructionAccount doesn't implement PartialEq
+    a_sorted
+        .iter()
+        .zip(b_sorted.iter())
+        .all(|(a_item, b_item)| {
+            a_item.index_in_transaction == b_item.index_in_transaction
+                && a_item.is_signer() == b_item.is_signer()
+                && a_item.is_writable() == b_item.is_writable()
+        })
 }
 
 fn compare_feature_sets(from_fixture: &FeatureSet, from_mollusk: &FeatureSet) {

--- a/harness/tests/precompile.rs
+++ b/harness/tests/precompile.rs
@@ -16,8 +16,23 @@ fn test_secp256k1() {
     let mollusk = Mollusk::default();
     let secret_key = libsecp256k1::SecretKey::random(&mut thread_rng());
 
+    let msg = b"hello";
+    let sk_bytes = secret_key.serialize();
+    let (sig, recid) = solana_secp256k1_program::sign_message(&sk_bytes, msg).unwrap();
+    let pubkey = libsecp256k1::PublicKey::from_secret_key(&secret_key);
+    let uncompressed = pubkey.serialize(); // 65 bytes, 0x04 || X(32) || Y(32)
+    let mut uncompressed_64 = [0u8; 64];
+    uncompressed_64.copy_from_slice(&uncompressed[1..65]);
+    let eth_address = solana_secp256k1_program::eth_address_from_pubkey(&uncompressed_64);
+    let instr = solana_secp256k1_program::new_secp256k1_instruction_with_signature(
+        msg,
+        &sig,
+        recid,
+        &eth_address,
+    );
+
     mollusk.process_and_validate_instruction(
-        &solana_secp256k1_program::new_secp256k1_instruction(&secret_key, b"hello"),
+        &instr,
         &[
             (Pubkey::new_unique(), Account::default()),
             (
@@ -32,11 +47,24 @@ fn test_secp256k1() {
 #[allow(deprecated)]
 #[test]
 fn test_ed25519() {
+    use ed25519_dalek::Signer;
     let mollusk = Mollusk::default();
-    let secret_key = ed25519_dalek::Keypair::generate(&mut thread_rng());
+    let keypair = ed25519_dalek::Keypair::generate(&mut thread_rng());
+
+    let msg = b"hello";
+    let signature = keypair.sign(msg).to_bytes();
+    let pubkey_bytes = keypair.public.to_bytes();
+
+    let instr = solana_ed25519_program::new_ed25519_instruction_with_signature(
+        msg,
+        <&[u8; solana_ed25519_program::SIGNATURE_SERIALIZED_SIZE]>::try_from(&signature[..])
+            .unwrap(),
+        <&[u8; solana_ed25519_program::PUBKEY_SERIALIZED_SIZE]>::try_from(&pubkey_bytes[..])
+            .unwrap(),
+    );
 
     mollusk.process_and_validate_instruction(
-        &solana_ed25519_program::new_ed25519_instruction(&secret_key, b"hello"),
+        &instr,
         &[
             (Pubkey::new_unique(), Account::default()),
             (solana_sdk_ids::ed25519_program::id(), precompile_account()),
@@ -49,7 +77,8 @@ fn test_ed25519() {
 #[test]
 fn test_secp256r1() {
     use openssl::{
-        ec::{EcGroup, EcKey},
+        bn::BigNumContext,
+        ec::{EcGroup, EcKey, PointConversionForm},
         nid::Nid,
     };
 
@@ -60,8 +89,26 @@ fn test_secp256r1() {
         EcKey::generate(&group).unwrap()
     };
 
+    let sig =
+        solana_secp256r1_program::sign_message(b"hello", &secret_key.private_key_to_der().unwrap())
+            .unwrap();
+    let mut ctx = BigNumContext::new().unwrap();
+    let pub_bytes = secret_key
+        .public_key()
+        .to_bytes(
+            secret_key.group(),
+            PointConversionForm::COMPRESSED,
+            &mut ctx,
+        )
+        .unwrap();
+    let mut pubkey = [0u8; solana_secp256r1_program::COMPRESSED_PUBKEY_SERIALIZED_SIZE];
+    pubkey.copy_from_slice(&pub_bytes);
+
+    let instr =
+        solana_secp256r1_program::new_secp256r1_instruction_with_signature(b"hello", &sig, &pubkey);
+
     mollusk.process_and_validate_instruction(
-        &solana_secp256r1_program::new_secp256r1_instruction(b"hello", secret_key).unwrap(),
+        &instr,
         &[
             (Pubkey::new_unique(), Account::default()),
             (solana_sdk_ids::ed25519_program::id(), precompile_account()),

--- a/keys/src/accounts.rs
+++ b/keys/src/accounts.rs
@@ -36,23 +36,13 @@ pub fn compile_instruction_accounts(
     compiled_instruction
         .accounts
         .iter()
-        .enumerate()
-        .map(|(ix_account_index, &index_in_transaction)| {
-            let index_in_callee = compiled_instruction
-                .accounts
-                .get(0..ix_account_index)
-                .unwrap()
-                .iter()
-                .position(|&account_index| account_index == index_in_transaction)
-                .unwrap_or(ix_account_index) as IndexOfAccount;
+        .map(|&index_in_transaction| {
             let index_in_transaction = index_in_transaction as usize;
-            InstructionAccount {
-                index_in_transaction: index_in_transaction as IndexOfAccount,
-                index_in_caller: index_in_transaction as IndexOfAccount,
-                index_in_callee,
-                is_signer: key_map.is_signer_at_index(index_in_transaction),
-                is_writable: key_map.is_writable_at_index(index_in_transaction),
-            }
+            InstructionAccount::new(
+                index_in_transaction as IndexOfAccount,
+                key_map.is_signer_at_index(index_in_transaction),
+                key_map.is_writable_at_index(index_in_transaction),
+            )
         })
         .collect()
 }

--- a/programs/token/Cargo.toml
+++ b/programs/token/Cargo.toml
@@ -12,13 +12,14 @@ version = { workspace = true }
 [features]
 default = ["token", "associated-token", "token-2022"]
 token = []
-associated-token = ["dep:spl-associated-token-account"]
+associated-token = ["dep:spl-associated-token-account-interface"]
 token-2022 = []
 
 [dependencies]
 mollusk-svm = { workspace = true }
 solana-account = { workspace = true }
+solana-program-pack = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
-spl-token = { workspace = true }
-spl-associated-token-account = { workspace = true, optional = true  }
+spl-token-interface = { workspace = true }
+spl-associated-token-account-interface = { workspace = true, optional = true  }

--- a/programs/token/src/associated_token.rs
+++ b/programs/token/src/associated_token.rs
@@ -1,10 +1,8 @@
 use {
-    mollusk_svm::Mollusk,
-    solana_account::Account,
-    solana_pubkey::Pubkey,
-    solana_rent::Rent,
-    spl_associated_token_account::get_associated_token_address_with_program_id,
-    spl_token::{solana_program::program_pack::Pack, state::Account as TokenAccount},
+    mollusk_svm::Mollusk, solana_account::Account, solana_program_pack::Pack,
+    solana_pubkey::Pubkey, solana_rent::Rent,
+    spl_associated_token_account_interface::address::get_associated_token_address_with_program_id,
+    spl_token_interface::state::Account as TokenAccount,
 };
 
 pub const ID: Pubkey = solana_pubkey::pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");

--- a/programs/token/src/token.rs
+++ b/programs/token/src/token.rs
@@ -1,12 +1,10 @@
 use {
     mollusk_svm::Mollusk,
     solana_account::Account,
+    solana_program_pack::Pack,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
-    spl_token::{
-        solana_program::program_pack::Pack,
-        state::{Account as TokenAccount, Mint},
-    },
+    spl_token_interface::state::{Account as TokenAccount, Mint},
 };
 
 pub const ID: Pubkey = solana_pubkey::pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");

--- a/programs/token/src/token2022.rs
+++ b/programs/token/src/token2022.rs
@@ -1,12 +1,10 @@
 use {
     mollusk_svm::Mollusk,
     solana_account::Account,
+    solana_program_pack::Pack,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
-    spl_token::{
-        solana_program::program_pack::Pack,
-        state::{Account as TokenAccount, Mint},
-    },
+    spl_token_interface::state::{Account as TokenAccount, Mint},
 };
 
 pub const ID: Pubkey = solana_pubkey::pubkey!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");

--- a/test-programs/primary/src/lib.rs
+++ b/test-programs/primary/src/lib.rs
@@ -66,7 +66,7 @@ fn process_instruction(
                 return Err(ProgramError::MissingRequiredSignature);
             }
 
-            account_info.realloc(0, true)?;
+            account_info.resize(0)?;
             account_info.assign(&solana_sdk_ids::system_program::id());
 
             let lamports = account_info.lamports();


### PR DESCRIPTION
Updates Mollusk to use 3.0 crates (and 2.0 SPL interface crates when available).