### PR TITLE
Added custom CheckType & clarified panic behavior in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ Four main API methods are offered:
 
 * `process_instruction`: Process an instruction and return the result.
 * `process_and_validate_instruction`: Process an instruction and perform a
-  series of checks on the result, panicking if any checks fail.
+  series of checks on the result. By default, failing checks cause a panic,
+  but this behavior is configurable through `Mollusk::config`.
 * `process_instruction_chain`: Process a chain of instructions and return
   the result.
 * `process_and_validate_instruction_chain`: Process a chain of instructions
-  and perform a series of checks on each result, panicking if any checks
-  fail.
+  and perform a series of checks on each result. By default, failing checks
+  cause a panic, but this behavior is configurable through `Mollusk::config`.
 
 ## Single Instructions
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Four main API methods are offered:
   the result.
 * `process_and_validate_instruction_chain`: Process a chain of instructions
   and perform a series of checks on each result. By default, failing checks
-  cause a panic, but this behavior is configurable through `Mollusk::config`.
+  cause a panic, but this behavior is configurable through
+  `Mollusk::config`.
 
 ## Single Instructions
 

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -33,7 +33,8 @@
 //!   the result.
 //! * `process_and_validate_instruction_chain`: Process a chain of instructions
 //!   and perform a series of checks on each result. By default, failing checks
-//!   cause a panic, but this behavior is configurable through `Mollusk::config`.
+//!   cause a panic, but this behavior is configurable through
+//!   `Mollusk::config`.
 //!
 //! ## Single Instructions
 //!

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -27,12 +27,13 @@
 //!
 //! * `process_instruction`: Process an instruction and return the result.
 //! * `process_and_validate_instruction`: Process an instruction and perform a
-//!   series of checks on the result, panicking if any checks fail.
+//!   series of checks on the result. By default, failing checks cause a panic,
+//!   but this behavior is configurable through `Mollusk::config`.
 //! * `process_instruction_chain`: Process a chain of instructions and return
 //!   the result.
 //! * `process_and_validate_instruction_chain`: Process a chain of instructions
-//!   and perform a series of checks on each result, panicking if any checks
-//!   fail.
+//!   and perform a series of checks on each result. By default, failing checks
+//!   cause a panic, but this behavior is configurable through `Mollusk::config`.
 //!
 //! ## Single Instructions
 //!

--- a/result/src/check.rs
+++ b/result/src/check.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::{
-        config::{CheckContext, Config, compare, throw},
+        config::{compare, throw, CheckContext, Config},
         types::{InstructionResult, ProgramResult},
     },
     solana_account::{Account, ReadableAccount},
@@ -10,6 +10,8 @@ use {
     solana_program_error::ProgramError,
     solana_pubkey::Pubkey,
 };
+
+type AccountCheckFn = dyn Fn(&[(Pubkey, Account)]) -> bool;
 
 enum CheckType<'a> {
     /// Check the number of compute units consumed by the instruction.
@@ -25,7 +27,7 @@ enum CheckType<'a> {
     /// Check that all accounts are rent exempt.
     AllRentExempt,
     /// Custom check for accounts.
-    Custom((Box<dyn Fn(&[(Pubkey, Account)]) -> bool>, &'static str)),
+    Custom((Box<AccountCheckFn>, &'static str)),
 }
 
 pub struct Check<'a> {
@@ -308,9 +310,9 @@ impl InstructionResult {
                         }
                     }
                 }
-                CheckType::Custom((function, function_name))=>{
-                        println!("Calling {}", *function_name);
-                        pass &= function(&self.resulting_accounts);
+                CheckType::Custom((function, function_name)) => {
+                    println!("Calling {}", *function_name);
+                    pass &= function(&self.resulting_accounts);
                 }
             }
         }


### PR DESCRIPTION
###Summary of Changes

Two changes are added:-

##Custom Check Support

It allows for custom program checks to be added to the regular check flow

- Added a new Custom variant to the CheckType enum.

- Added a corresponding helper (Check::custom) that allows to provide a custom validation function alongside a descriptive name.

- Extended the check handler logic to handle the new Custom case, allowing user-supplied functions to be invoked during validation just like the built-in checks.

##Documentation Updates on Panic Behavior

Updated documentation for process_and_validate_instruction and process_and_validate_instruction_chain.

- Clarified that checks panic by default, but this behavior is configurable through Mollusk::config.