### PR TITLE
harness: don't stub program account if it was provided

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ clippy-fix:
 check-features:
 	@cargo hack check --feature-powerset --no-dev-deps
 
+build:
+	@$(MAKE) build-test-programs
+	@cargo build
+
 test:
 	@$(MAKE) build-test-programs
 	@cargo test --all-features


### PR DESCRIPTION
The harness always stubs out the program account, which is similar to how the runtime behaves. However, the runtime won't stub it if it's been specified in the instruction's accounts list.

This PR adjusts the harness to only stub the program account if it has not been provided in the accounts list.