### PR TITLE
Process instruction with observer

### DIFF
--- a/harness/tests/bpf_program.rs
+++ b/harness/tests/bpf_program.rs
@@ -152,7 +152,7 @@ fn test_transfer() {
         ],
         &[
             Check::success(),
-            Check::compute_units(2533),
+            Check::compute_units(2524),
             Check::account(&payer)
                 .lamports(payer_lamports - transfer_amount)
                 .build(),
@@ -256,7 +256,7 @@ fn test_close_account() {
         ],
         &[
             Check::success(),
-            Check::compute_units(2608),
+            Check::compute_units(2599),
             Check::account(&key)
                 .closed() // The rest is unnecessary, just testing.
                 .data(&[])
@@ -376,7 +376,7 @@ fn test_cpi() {
         ],
         &[
             Check::success(),
-            Check::compute_units(2418),
+            Check::compute_units(2411),
             Check::account(&key)
                 .data(data)
                 .lamports(lamports)

--- a/harness/tests/observer.rs
+++ b/harness/tests/observer.rs
@@ -1,0 +1,94 @@
+use {
+    mollusk_svm::{result::Check, Mollusk},
+    solana_account::{Account, ReadableAccount},
+    solana_instruction::{AccountMeta, Instruction},
+    solana_pubkey::Pubkey,
+    solana_svm_log_collector::LogCollector,
+    std::cell::RefCell,
+    std::rc::Rc,
+};
+
+#[test]
+fn test_observer_accesses_result_logs_and_context() {
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+
+    let program_id = Pubkey::new_unique();
+    let mut mollusk = Mollusk::new(&program_id, "test_program_primary");
+    // Provide a log collector so logs are available via the context.
+    mollusk.logger = Some(Rc::new(RefCell::new(LogCollector::default())));
+
+    // A simple write-data instruction that succeeds.
+    let data = vec![9u8, 8, 7, 6];
+    let space = data.len();
+    let lamports = mollusk.sysvars.rent.minimum_balance(space);
+
+    let key = Pubkey::new_unique();
+    let account = Account::new(lamports, space, &program_id);
+
+    let instruction = {
+        let mut instruction_data = vec![1];
+        instruction_data.extend_from_slice(&data);
+        Instruction::new_with_bytes(
+            program_id,
+            &instruction_data,
+            vec![AccountMeta::new(key, true)],
+        )
+    };
+
+    // Captured state from the observer.
+    let observed_compute_units = Rc::new(RefCell::new(0u64));
+    let observed_owner = Rc::new(RefCell::new(None::<Pubkey>));
+    let observed_data_len = Rc::new(RefCell::new(0usize));
+    let observed_account_data = Rc::new(RefCell::new(Vec::<u8>::new()));
+    let observed_logs_match = Rc::new(RefCell::new(false));
+
+    let cu_ref = observed_compute_units.clone();
+    let owner_ref = observed_owner.clone();
+    let data_len_ref = observed_data_len.clone();
+    let data_ref = observed_account_data.clone();
+    let logs_ok_ref = observed_logs_match.clone();
+
+    let result = mollusk.process_and_validate_instruction_with_observer(
+        &instruction,
+        &[(key, account.clone())],
+        &[Check::success()],
+        move |res, ctx| {
+            // Access compute units from the result.
+            *cu_ref.borrow_mut() = res.compute_units_consumed;
+
+            // Access full context to inspect accounts.
+            if let Some(index) = ctx.transaction_context.find_index_of_account(&key) {
+                let acc = ctx
+                    .transaction_context
+                    .accounts()
+                    .try_borrow(index)
+                    .unwrap()
+                    .clone();
+                *owner_ref.borrow_mut() = Some(*acc.owner());
+                let data_vec = acc.data().to_vec();
+                *data_len_ref.borrow_mut() = data_vec.len();
+                *data_ref.borrow_mut() = data_vec;
+            }
+
+            // Access and validate logs via the context's log collector.
+            if let Some(logs_rc) = ctx.get_log_collector() {
+                let logs_dbg = logs_rc.borrow().get_recorded_content().join("\n");
+                let pid = program_id.to_string();
+                let ok = logs_dbg.contains(&format!("Program {} invoke", pid))
+                    && logs_dbg.contains("consumed 384")
+                    && logs_dbg.contains(&format!("Program {} success", pid));
+                *logs_ok_ref.borrow_mut() = ok;
+            }
+        },
+    );
+
+    // Normal checks still pass.
+    assert!(result.program_result.is_ok());
+
+    // The observer should have captured compute units and account state.
+    assert_eq!(*observed_compute_units.borrow(), 384);
+    assert_eq!(observed_owner.borrow().unwrap(), program_id);
+    assert_eq!(*observed_data_len.borrow(), space);
+    assert_eq!(&*observed_account_data.borrow(), &data);
+    assert!(*observed_logs_match.borrow());
+}


### PR DESCRIPTION
[WIP] more docs etc. incoming shortly, plus an evaluation of any overlap with #161 

### Problem
Callers can have some difficulty retrieving all information about a processed mollusk instruction or instruction chain. In particular, updating tests to compare CUs, account states, and results can be a bit tedious.

### Solution
Allow an observer to be passed in to the new `with_observer` wrapper functions. This observer is handed all the relevant information so that the caller's testing setup can easily process it.

### Context
This is part of a [simple solution](https://github.com/rustopian/compare-programs) to provide developers an easy `#[compare_programs]` attribute, which makes a test compare CUs and check byte-for-byte parity of accounts, data, and instruction results, across any arbitrary number of versions of a program.