### PR TITLE
harness: put precompile libs behind feature flag

### DIFF
--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -25,6 +25,7 @@ fuzz-fd = [
     "dep:mollusk-svm-fuzz-fs",
 ]
 invocation-inspect-callback = []
+precompiles = ["dep:agave-precompiles"]
 serde = [
     "dep:serde",
     "mollusk-svm-result/serde",
@@ -32,7 +33,7 @@ serde = [
 
 [dependencies]
 agave-feature-set = { workspace = true }
-agave-precompiles = { workspace = true }
+agave-precompiles = { workspace = true, optional = true }
 agave-syscalls = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }

--- a/harness/src/program.rs
+++ b/harness/src/program.rs
@@ -31,6 +31,7 @@ pub mod loader_keys {
     };
 }
 
+#[cfg(feature = "precompiles")]
 pub mod precompile_keys {
     use solana_pubkey::Pubkey;
     pub use solana_sdk_ids::{
@@ -43,6 +44,15 @@ pub mod precompile_keys {
             *program_id,
             ED25519_PROGRAM | SECP256K1_PROGRAM | SECP256R1_PROGRAM
         )
+    }
+}
+
+#[cfg(not(feature = "precompiles"))]
+pub mod precompile_keys {
+    use solana_pubkey::Pubkey;
+
+    pub(crate) fn is_precompile(_program_id: &Pubkey) -> bool {
+        false
     }
 }
 


### PR DESCRIPTION
This should help keep heavy dependencies out of the base library, such as `openssl`.