### PR TITLE
harness: Add program with loader helper

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -140,8 +140,8 @@ fn add_elf_to_mollusk(mollusk: &mut Mollusk, elf_path: &str, program_id: &Pubkey
     let elf = mollusk_svm::file::read_file(elf_path);
     mollusk.add_program_with_loader_and_elf(
         program_id,
-        &elf,
         &solana_sdk_ids::bpf_loader_upgradeable::id(),
+        &elf,
     );
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -138,7 +138,7 @@ fn search_paths(path: &str, extension: &str) -> Result<Vec<String>, Box<dyn std:
 
 fn add_elf_to_mollusk(mollusk: &mut Mollusk, elf_path: &str, program_id: &Pubkey) {
     let elf = mollusk_svm::file::read_file(elf_path);
-    mollusk.add_program_with_elf_and_loader(
+    mollusk.add_program_with_loader_and_elf(
         program_id,
         &elf,
         &solana_sdk_ids::bpf_loader_upgradeable::id(),

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -655,23 +655,35 @@ impl Mollusk {
     /// - The current working directory
     pub fn new(program_id: &Pubkey, program_name: &str) -> Self {
         let mut mollusk = Self::default();
-        mollusk.add_program(program_id, program_name, &DEFAULT_LOADER_KEY);
+        mollusk.add_program(program_id, program_name);
         mollusk
     }
 
     /// Add a program to the test environment.
     ///
     /// If you intend to CPI to a program, this is likely what you want to use.
-    pub fn add_program(&mut self, program_id: &Pubkey, program_name: &str, loader_key: &Pubkey) {
+    pub fn add_program(&mut self, program_id: &Pubkey, program_name: &str) {
+        self.add_program_with_loader(program_id, program_name, &DEFAULT_LOADER_KEY);
+    }
+
+    /// Add a program to the test environment under the specified loader.
+    ///
+    /// If you intend to CPI to a program, this is likely what you want to use.
+    pub fn add_program_with_loader(
+        &mut self,
+        program_id: &Pubkey,
+        program_name: &str,
+        loader_key: &Pubkey,
+    ) {
         let elf = file::load_program_elf(program_name);
-        self.add_program_with_elf_and_loader(program_id, &elf, loader_key);
+        self.add_program_with_loader_and_elf(program_id, &elf, loader_key);
     }
 
     /// Add a program to the test environment using a provided ELF under a
     /// specific loader.
     ///
     /// If you intend to CPI to a program, this is likely what you want to use.
-    pub fn add_program_with_elf_and_loader(
+    pub fn add_program_with_loader_and_elf(
         &mut self,
         program_id: &Pubkey,
         elf: &[u8],

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -676,7 +676,7 @@ impl Mollusk {
         loader_key: &Pubkey,
     ) {
         let elf = file::load_program_elf(program_name);
-        self.add_program_with_loader_and_elf(program_id, &elf, loader_key);
+        self.add_program_with_loader_and_elf(program_id, loader_key, &elf);
     }
 
     /// Add a program to the test environment using a provided ELF under a
@@ -686,8 +686,8 @@ impl Mollusk {
     pub fn add_program_with_loader_and_elf(
         &mut self,
         program_id: &Pubkey,
-        elf: &[u8],
         loader_key: &Pubkey,
+        elf: &[u8],
     ) {
         self.program_cache.add_program(program_id, loader_key, elf);
     }

--- a/harness/tests/account_store.rs
+++ b/harness/tests/account_store.rs
@@ -151,7 +151,7 @@ fn test_account_store_sysvars_and_programs() {
 
     // Add another test program to the test environment.
     let other_program_id = Pubkey::new_unique();
-    context.mollusk.add_program(
+    context.mollusk.add_program_with_loader(
         &other_program_id,
         "test_program_cpi_target",
         &mollusk_svm::program::loader_keys::LOADER_V3,

--- a/harness/tests/bpf_program.rs
+++ b/harness/tests/bpf_program.rs
@@ -317,7 +317,7 @@ fn test_cpi() {
         );
     }
 
-    mollusk.add_program(
+    mollusk.add_program_with_loader(
         &cpi_target_program_id,
         "test_program_cpi_target",
         &mollusk_svm::program::loader_keys::LOADER_V3,

--- a/harness/tests/custom_syscall.rs
+++ b/harness/tests/custom_syscall.rs
@@ -42,7 +42,7 @@ fn test_custom_syscall() {
             .program_runtime_environment
             .register_function("sol_burn_cus", SyscallBurnCus::vm)
             .unwrap();
-        mollusk.add_program(
+        mollusk.add_program_with_loader(
             &program_id,
             "test_program_custom_syscall",
             &mollusk_svm::program::loader_keys::LOADER_V3,

--- a/programs/memo/src/memo.rs
+++ b/programs/memo/src/memo.rs
@@ -6,7 +6,7 @@ pub const ELF: &[u8] = include_bytes!("elf/memo.so");
 
 pub fn add_program(mollusk: &mut Mollusk) {
     // Loader v2
-    mollusk.add_program_with_elf_and_loader(
+    mollusk.add_program_with_loader_and_elf(
         &ID,
         ELF,
         &mollusk_svm::program::loader_keys::LOADER_V2,

--- a/programs/memo/src/memo.rs
+++ b/programs/memo/src/memo.rs
@@ -8,8 +8,8 @@ pub fn add_program(mollusk: &mut Mollusk) {
     // Loader v2
     mollusk.add_program_with_loader_and_elf(
         &ID,
-        ELF,
         &mollusk_svm::program::loader_keys::LOADER_V2,
+        ELF,
     );
 }
 

--- a/programs/memo/src/memo_v1.rs
+++ b/programs/memo/src/memo_v1.rs
@@ -8,8 +8,8 @@ pub fn add_program(mollusk: &mut Mollusk) {
     // Loader v1
     mollusk.add_program_with_loader_and_elf(
         &ID,
-        ELF,
         &mollusk_svm::program::loader_keys::LOADER_V1,
+        ELF,
     );
 }
 

--- a/programs/memo/src/memo_v1.rs
+++ b/programs/memo/src/memo_v1.rs
@@ -6,7 +6,7 @@ pub const ELF: &[u8] = include_bytes!("elf/memo-v1.so");
 
 pub fn add_program(mollusk: &mut Mollusk) {
     // Loader v1
-    mollusk.add_program_with_elf_and_loader(
+    mollusk.add_program_with_loader_and_elf(
         &ID,
         ELF,
         &mollusk_svm::program::loader_keys::LOADER_V1,

--- a/programs/token/src/associated_token.rs
+++ b/programs/token/src/associated_token.rs
@@ -15,7 +15,7 @@ pub const ELF: &[u8] = include_bytes!("elf/associated_token.so");
 
 pub fn add_program(mollusk: &mut Mollusk) {
     // Loader v2
-    mollusk.add_program_with_elf_and_loader(
+    mollusk.add_program_with_loader_and_elf(
         &ID,
         ELF,
         &mollusk_svm::program::loader_keys::LOADER_V2,

--- a/programs/token/src/associated_token.rs
+++ b/programs/token/src/associated_token.rs
@@ -17,8 +17,8 @@ pub fn add_program(mollusk: &mut Mollusk) {
     // Loader v2
     mollusk.add_program_with_loader_and_elf(
         &ID,
-        ELF,
         &mollusk_svm::program::loader_keys::LOADER_V2,
+        ELF,
     );
 }
 

--- a/programs/token/src/token.rs
+++ b/programs/token/src/token.rs
@@ -13,7 +13,7 @@ pub const ELF: &[u8] = include_bytes!("elf/token.so");
 
 pub fn add_program(mollusk: &mut Mollusk) {
     // Loader v2
-    mollusk.add_program_with_elf_and_loader(
+    mollusk.add_program_with_loader_and_elf(
         &ID,
         ELF,
         &mollusk_svm::program::loader_keys::LOADER_V2,

--- a/programs/token/src/token.rs
+++ b/programs/token/src/token.rs
@@ -15,8 +15,8 @@ pub fn add_program(mollusk: &mut Mollusk) {
     // Loader v2
     mollusk.add_program_with_loader_and_elf(
         &ID,
-        ELF,
         &mollusk_svm::program::loader_keys::LOADER_V2,
+        ELF,
     );
 }
 

--- a/programs/token/src/token2022.rs
+++ b/programs/token/src/token2022.rs
@@ -15,8 +15,8 @@ pub fn add_program(mollusk: &mut Mollusk) {
     // Loader v3
     mollusk.add_program_with_loader_and_elf(
         &ID,
-        ELF,
         &mollusk_svm::program::loader_keys::LOADER_V3,
+        ELF,
     );
 }
 

--- a/programs/token/src/token2022.rs
+++ b/programs/token/src/token2022.rs
@@ -13,7 +13,7 @@ pub const ELF: &[u8] = include_bytes!("elf/token_2022.so");
 
 pub fn add_program(mollusk: &mut Mollusk) {
     // Loader v3
-    mollusk.add_program_with_elf_and_loader(
+    mollusk.add_program_with_loader_and_elf(
         &ID,
         ELF,
         &mollusk_svm::program::loader_keys::LOADER_V3,


### PR DESCRIPTION
### Problem

While there are a couple of `add_program*` helpers, there is none that adds a program under the `DEFAULT_LOADER_KEY`. This requires to always have to specify a loader when adding additional programs – see [here](https://github.com/febo/tide/blob/main/benchmark/benches/account.rs#L19-L37).

### Solution

Refactor the helpers to include 3 different variations:
* `add_program`
* `add_program_with_loader`
* `add_program_with_loader_and_elf`