### PR TITLE
fix: avoid creating default account for ix sysvar

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -1368,7 +1368,7 @@ impl<AS: AccountStore> MolluskContext<AS> {
                 .accounts
                 .iter()
                 .for_each(|AccountMeta { pubkey, .. }| {
-                    if seen.insert(*pubkey) && != &solana_instructions_sysvar::id() {
+                    if seen.insert(*pubkey) && pubkey != &solana_instructions_sysvar::id() {
                         // First try to load theirs, then see if it's a sysvar,
                         // then see if it's a cached program, then apply the
                         // default.


### PR DESCRIPTION
The fallback logic introduced in https://github.com/anza-xyz/mollusk/pull/156 for the ix sysvar wasn't triggered for `MolluskContext` bc a default account was being created. This causes the runtime to reject the account as it has the wrong owner.