### PR TITLE
fix: ix chains reuse cumulative accounts

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -1064,6 +1064,8 @@ impl Mollusk {
         );
 
         for (index, instruction) in instructions.iter().enumerate() {
+            let accounts = &composite_result.resulting_accounts;
+
             let (sanitized_message, transaction_accounts) =
                 crate::compile_accounts::compile_accounts(
                     instruction,


### PR DESCRIPTION
For the non-validating method `process_instruction_chain`, we weren't passing the last instruction's returned accounts to the next instruction.