### PR TITLE
feat: Dump a register trace disassembly if SBF_TRACE_DISASSEMBLE is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,5 +639,6 @@ mollusk.invocation_inspect_callback = Box::new(EmptyInvocationInspectCallback {}
 mollusk.invocation_inspect_callback =
     Box::new(register_tracing::DefaultRegisterTracingCallback {
         sbf_trace_dir: std::env::var("SBF_TRACE_DIR").unwrap(),
+        sbf_trace_disassemble: std::env::var("SBF_TRACE_DISASSEMBLE").is_ok(),
     });
 ```

--- a/harness/src/register_tracing.rs
+++ b/harness/src/register_tracing.rs
@@ -37,7 +37,7 @@ impl DefaultRegisterTracingCallback {
         ) {
             Ok(analysis) => {
                 if let Err(e) = analysis.disassemble_register_trace(writer, register_trace) {
-                    eprintln!("Can't dissasemble register trace for {program_id}: {e:#?}");
+                    eprintln!("Can't disassemble register trace for {program_id}: {e:#?}");
                 }
             }
             Err(e) => {
@@ -73,7 +73,7 @@ impl DefaultRegisterTracingCallback {
 
         // Persist a full trace disassembly if requested.
         if self.sbf_trace_disassemble {
-            let mut trace_disassemble_file = File::create(base_fname.with_extension("disassem"))?;
+            let mut trace_disassemble_file = File::create(base_fname.with_extension("trace"))?;
             self.disassemble_register_trace(
                 &mut trace_disassemble_file,
                 program_id,


### PR DESCRIPTION
### What's changed

Dump a register trace disassembly if requested by user taking advantage of the API in `solana-sbpf`.