### PR TITLE
fix: prevent duplicate sysvar accounts and ensure sysvars in fixtures

### DIFF
--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -1792,35 +1792,37 @@ impl<AS: AccountStore> MolluskContext<AS> {
                 .program_cache
                 .get_all_keyed_program_accounts()
                 .into_iter()
-                .chain(self.mollusk.sysvars.get_all_keyed_sysvar_accounts())
                 .for_each(|(pubkey, account)| {
                     accounts.push((pubkey, account));
                 });
         }
+        let store = self.account_store.borrow();
+        self.mollusk
+            .sysvars
+            .get_all_keyed_sysvar_accounts()
+            .into_iter()
+            .for_each(|(pubkey, account)| {
+                if store.get_account(&pubkey).is_none() {
+                    accounts.push((pubkey, account));
+                }
+            });
 
         // Regardless of hydration, only add an account if the caller hasn't
         // already loaded it into the store.
-        let mut seen = HashSet::new();
-        let store = self.account_store.borrow();
+        let mut seen: HashSet<Pubkey> = accounts.iter().map(|(k, _)| *k).collect();
         instructions.for_each(|instruction| {
             instruction
                 .accounts
                 .iter()
                 .for_each(|AccountMeta { pubkey, .. }| {
                     if seen.insert(*pubkey) && pubkey != &solana_instructions_sysvar::id() {
-                        // First try to load theirs, then see if it's a sysvar,
-                        // then see if it's a cached program, then apply the
-                        // default.
+                        // First try to load theirs, then see if it's a cached program, then apply
+                        // the default.
                         let account = store.get_account(pubkey).unwrap_or_else(|| {
                             self.mollusk
-                                .sysvars
-                                .maybe_create_sysvar_account(pubkey)
-                                .unwrap_or_else(|| {
-                                    self.mollusk
-                                        .program_cache
-                                        .maybe_create_program_account(pubkey)
-                                        .unwrap_or_else(|| store.default_account(pubkey))
-                                })
+                                .program_cache
+                                .maybe_create_program_account(pubkey)
+                                .unwrap_or_else(|| store.default_account(pubkey))
                         });
                         accounts.push((*pubkey, account));
                     }

--- a/harness/src/sysvar.rs
+++ b/harness/src/sysvar.rs
@@ -77,28 +77,6 @@ impl Sysvars {
         (T::id(), account)
     }
 
-    pub(crate) fn maybe_create_sysvar_account(&self, pubkey: &Pubkey) -> Option<Account> {
-        if pubkey.eq(&Clock::id()) {
-            Some(self.sysvar_account(&self.clock).1)
-        } else if pubkey.eq(&EpochRewards::id()) {
-            Some(self.sysvar_account(&self.epoch_rewards).1)
-        } else if pubkey.eq(&EpochSchedule::id()) {
-            Some(self.sysvar_account(&self.epoch_schedule).1)
-        } else if pubkey.eq(&LastRestartSlot::id()) {
-            Some(self.sysvar_account(&self.last_restart_slot).1)
-        } else if pubkey.eq(&Rent::id()) {
-            Some(self.sysvar_account(&self.rent).1)
-        } else if pubkey.eq(&SlotHashes::id()) {
-            Some(self.sysvar_account(&self.slot_hashes).1)
-        } else if pubkey.eq(&StakeHistory::id()) {
-            Some(self.sysvar_account(&self.stake_history).1)
-        } else if pubkey.eq(&RecentBlockhashes::id()) {
-            Some(self.sysvar_account(&self.recent_blockhashes).1)
-        } else {
-            None
-        }
-    }
-
     /// Get the key and account for the clock sysvar.
     pub fn keyed_account_for_clock_sysvar(&self) -> (Pubkey, Account) {
         self.sysvar_account(&self.clock)


### PR DESCRIPTION
Two bugs in `load_accounts_for_instructions`:

1. `seen` was initialized empty after sysvars were already pushed into `accounts`, so instruction-referenced sysvars were added a second time, triggering a "duplicate program account" invariant violation. Fix: seed `seen` from the already-collected accounts.

2. Sysvars were only added when `hydrate_store` was enabled. Mollusk execution worked (sysvar cache is populated separately), but serialized fixtures couldn't find sysvar accounts. Fix: add sysvars unconditionally, guarded only by whether the store already provides an override.

These bugs were causing exported instr fixtures to fail in solfuzz-agave .