### PR TITLE
cli: (fix) ignore compute units flag check override

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -145,38 +145,6 @@ fn add_elf_to_mollusk(mollusk: &mut Mollusk, elf_path: &str, program_id: &Pubkey
     );
 }
 
-fn resolve_checks(
-    checks_from_config: Option<Vec<Compare>>,
-    ignore_compute_units: bool,
-) -> Vec<Compare> {
-    let mut checks = if let Some(config_checks) = checks_from_config {
-        config_checks
-    } else if ignore_compute_units {
-        // Defaults to all checks except compute units when requested.
-        Compare::everything_but_cus()
-    } else {
-        // Defaults to all checks.
-        Compare::everything()
-    };
-
-    // Ditch ComputeUnits checks to reflect CU flag override.
-    if ignore_compute_units {
-        checks.retain(|check| !matches!(check, Compare::ComputeUnits));
-    }
-
-    checks
-}
-
-fn set_checks(
-    config: Option<String>,
-    ignore_compute_units: bool,
-) -> Result<Vec<Compare>, Box<dyn std::error::Error>> {
-    let checks_from_config = config
-        .map(|config_path| ConfigFile::try_load(&config_path).map(|config_file| config_file.checks))
-        .transpose()?;
-    Ok(resolve_checks(checks_from_config, ignore_compute_units))
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match Cli::parse().command {
@@ -196,7 +164,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut mollusk = Mollusk::default();
             add_elf_to_mollusk(&mut mollusk, &elf_path, &program_id);
 
-            let checks = set_checks(config, ignore_compute_units)?;
+            let checks = if let Some(config_path) = config {
+                let mut checks = ConfigFile::try_load(&config_path)?.checks;
+                if ignore_compute_units {
+                    checks.retain(|check| !matches!(check, Compare::ComputeUnits));
+                }
+                checks
+            } else if ignore_compute_units {
+                Compare::everything_but_cus()
+            } else {
+                // Defaults to all checks.
+                Compare::everything()
+            };
+
             let fixtures = search_paths(&fixture, "fix")?;
 
             Runner::new(
@@ -230,7 +210,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut mollusk_test = Mollusk::default();
             add_elf_to_mollusk(&mut mollusk_test, &elf_path_target, &program_id);
 
-            let checks = set_checks(config, ignore_compute_units)?;
+            let checks = if let Some(config_path) = config {
+                let mut checks = ConfigFile::try_load(&config_path)?.checks;
+                if ignore_compute_units {
+                    checks.retain(|check| !matches!(check, Compare::ComputeUnits));
+                }
+                checks
+            } else if ignore_compute_units {
+                Compare::everything_but_cus()
+            } else {
+                // Defaults to all checks.
+                Compare::everything()
+            };
+
             let fixtures = search_paths(&fixture, "fix")?;
 
             Runner::new(
@@ -245,25 +237,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resolve_checks_removes_compute_units_from_config_when_ignored() {
-        let checks = vec![Compare::ComputeUnits, Compare::ProgramResult];
-        let resolved = resolve_checks(Some(checks), true);
-
-        assert!(resolved
-            .iter()
-            .any(|check| matches!(check, Compare::ProgramResult)));
-        assert!(
-            !resolved
-                .iter()
-                .any(|check| matches!(check, Compare::ComputeUnits)),
-            "ComputeUnits should be removed when ignore_compute_units=true"
-        );
-    }
 }


### PR DESCRIPTION
### Issue

As per flag description `ignore_compute_units` when set, should remove `ComputeUnits` from checks list, which it didn't in case of provided with config.

### Summary of changes
- Small refactor around checks loading and fixed the issue
- Added test