### PR TITLE
adding trusted publishing + SLSA provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           cache: true
           version: ${{ steps.solana.outputs.version }}
-      - uses: rust-lang/crates-io-auth-action@v1
+      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec  # v1.0.3
         id: auth
       - name: Publish
         shell: bash
@@ -82,6 +82,6 @@ jobs:
           ARGS: "--locked"
         run: make publish
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
         with:
           subject-path: target/package/*.crate


### PR DESCRIPTION
Replacing the `CRATES_IO_TOKEN` secret with OIDC-based trusted publishing via `rust-lang/crates-io-auth-action`. This eliminates the need for a long-lived API token in repo secrets.

**Changes:**

- Add `rust-lang/crates-io-auth-action@v1` to obtain a short-lived OIDC token at publish time
- Gate the publish job on a prod environment for an additional approval layer
- Add SLSA build provenance attestation for all published .crate files via `actions/attest-build-provenance@v4`
- Add `permissions: {}` at workflow level and explicit per-job permission blocks
- Add `permissions: contents: read` to pre_publish (required after tightening workflow-level defaults) 

**Required setup before merging:**

- Create a prod environment in GitHub repo settings
- Add a trusted publisher on crates.io for each of the 10 crates (owner: anza-xyz, repo: mollusk, workflow: publish.yml, environment: prod)
- Delete the `CRATES_IO_TOKEN` secret once the new workflow is confirmed working