### PR TITLE
tests: add ELF loading tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ SHELL := /usr/bin/env bash
 NIGHTLY_TOOLCHAIN := nightly-2025-10-07
 SOLANA_VERSION := 4.0.0-beta.6
 
-.PHONY: audit build-test-programs prepublish publish format format-check \
-	clippy test check-features all-checks nightly-version solana-version
+.PHONY: audit build-test-programs build-test-elfs prepublish publish format \
+	format-check clippy test check-features all-checks nightly-version \
+	solana-version
 
 # Print the nightly toolchain version for CI
 nightly-version:
@@ -33,6 +34,18 @@ build-test-programs:
 	@cargo build-sbf --manifest-path test-programs/instructions-sysvar/Cargo.toml
 	@cargo build-sbf --manifest-path test-programs/noop-log/Cargo.toml
 	@cargo build-sbf --manifest-path test-programs/primary/Cargo.toml
+
+build-test-elfs:
+	@set -e; \
+	OUT_DIR=target/deploy; \
+	TMP_DIR=target/tmp; \
+	mkdir -p $$OUT_DIR $$TMP_DIR; \
+	for ARCH in v0 v1 v2 v3; do \
+		echo "Building test_program_cpi_target ($$ARCH)..."; \
+		cargo build-sbf --manifest-path test-programs/cpi-target/Cargo.toml --arch $$ARCH --sbf-out-dir $$TMP_DIR; \
+		mv $$TMP_DIR/test_program_cpi_target.so $$OUT_DIR/test_program_cpi_target_$${ARCH}.so; \
+	done; \
+	rm -rf $$TMP_DIR
 
 # Pre-publish checks
 prepublish:
@@ -85,10 +98,12 @@ check-features:
 
 build:
 	@$(MAKE) build-test-programs
+	@$(MAKE) build-test-elfs
 	@cargo build
 
 test:
 	@$(MAKE) build-test-programs
+	@$(MAKE) build-test-elfs
 	@cargo test --all-features
 
 # Run all checks in sequence

--- a/harness/tests/elf_loading.rs
+++ b/harness/tests/elf_loading.rs
@@ -1,0 +1,77 @@
+//! Tests for loading SBPF ELFs.
+
+use {
+    mollusk_svm::{program::ProgramCache, Mollusk},
+    solana_pubkey::Pubkey,
+};
+
+#[test]
+fn test_sbpf_v0_elf_loads() {
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+
+    let program_id = Pubkey::new_unique();
+    let mut mollusk = Mollusk::default();
+    mollusk.add_program(&program_id, "test_program_cpi_target_v0");
+}
+
+#[test]
+fn test_sbpf_v1_elf_loads() {
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+
+    let program_id = Pubkey::new_unique();
+    let mut mollusk = Mollusk::default();
+    mollusk.add_program(&program_id, "test_program_cpi_target_v1");
+}
+
+#[test]
+fn test_sbpf_v2_elf_loads() {
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+
+    let program_id = Pubkey::new_unique();
+    let mut mollusk = Mollusk::default();
+    mollusk.add_program(&program_id, "test_program_cpi_target_v2");
+}
+
+#[test]
+fn test_sbpf_v3_feature_is_active_by_default() {
+    let mollusk = Mollusk::default();
+    assert!(mollusk
+        .feature_set
+        .is_active(&agave_feature_set::enable_sbpf_v3_deployment_and_execution::id()));
+}
+
+#[test]
+fn test_sbpf_v3_elf_loads_with_feature_enabled() {
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+
+    let program_id = Pubkey::new_unique();
+    let mut mollusk = Mollusk::default();
+    mollusk.add_program(&program_id, "test_program_cpi_target_v3");
+}
+
+#[test]
+#[should_panic(expected = "called `Result::unwrap()` on an `Err` value: UnsupportedSBPFVersion")]
+fn test_sbpf_v3_elf_fails_without_feature() {
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+
+    let mut mollusk = Mollusk::default();
+    mollusk
+        .feature_set
+        .deactivate(&agave_feature_set::enable_sbpf_v3_deployment_and_execution::id());
+
+    // Rebuild the program cache with the updated feature set so that
+    // the runtime environment no longer includes V3 in
+    // `enabled_sbpf_versions`.
+    mollusk.program_cache = ProgramCache::new(&mollusk.feature_set, &mollusk.compute_budget, false);
+
+    let program_id = Pubkey::new_unique();
+    let elf = mollusk_svm::file::load_program_elf("test_program_cpi_target_v3");
+
+    // Loading a V3 ELF should fail because V3 is not in the
+    // enabled range.
+    mollusk.program_cache.add_program(
+        &program_id,
+        &solana_sdk_ids::bpf_loader_upgradeable::ID,
+        &elf,
+    );
+}


### PR DESCRIPTION
Adds some tests for Mollusk loading ELFs with different `SBPFVersion` variant `e_flags` headers.

Note: depends on #203 