### PR TITLE
ci: adding dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
           - "solana-*"
           - "agave-*"
           - "spl-*"
-      all-dependencies:
+      third-party:
         patterns:
           - "*"
 


### PR DESCRIPTION
Add Dependabot configuration for Cargo and GitHub Actions dependencies.

Weekly version updates on Mondays, with Solana/Agave/SPL packages grouped into a single PR. Security updates fire immediately, regardless of the schedule