### PR TITLE
ci: install protoc in CI workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
           key: cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-clippy-
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
       - name: Get nightly toolchain version
         id: nightly
         run: echo "version=$(make nightly-version)" >> $GITHUB_OUTPUT
@@ -60,6 +62,8 @@ jobs:
           key: cargo-hack-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-hack-
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@v2
         with:
@@ -80,6 +84,8 @@ jobs:
           key: cargo-build-sbf-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-build-sbf-
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
       - name: Get Solana version
         id: solana
         run: echo "version=$(make solana-version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
prost-build 0.14 requires an external protoc compiler, unlike 0.9 which bundled it. Install protobuf-compiler via apt in the three jobs that compile code (Clippy, Check Features, Build and Test).