### PR TITLE
Add sbpf-debugger feature with GDB remote stub support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -1528,6 +1534,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdbstub"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e02bf1b1a624d96925c608f1b268d82a76cbc587ce9e59f7c755e9ea11c75c"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "log",
+ "managed",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2016,6 +2036,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,7 +2442,7 @@ version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2894,7 +2920,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2957,7 +2983,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3627,7 +3653,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddf67876c541aa1e21ee1acae35c95c6fbc61119814bfef70579317a5e26955"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "solana-account-info",
  "solana-instruction",
  "solana-instruction-error",
@@ -3811,7 +3837,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad62e1045c2347a0c0e219a6ceb0abfe904be622920996bfcac8d116fabe3c7"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "solana-pubkey 4.1.0",
 ]
 
@@ -3990,6 +4016,7 @@ checksum = "733b3657a0fab205102b799dbe17f85d3972cf984232c1b0b108fa6ba438e382"
 dependencies = [
  "byteorder",
  "combine",
+ "gdbstub",
  "hash32",
  "libc",
  "log",
@@ -5038,7 +5065,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5245,7 +5272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/README.md
+++ b/README.md
@@ -645,6 +645,8 @@ mollusk.invocation_inspect_callback =
     Box::new(register_tracing::DefaultRegisterTracingCallback {
         sbf_trace_dir: std::env::var("SBF_TRACE_DIR").unwrap(),
         sbf_trace_disassemble: std::env::var("SBF_TRACE_DISASSEMBLE").is_ok(),
-        sbf_debug_port: std::env::var("SBF_DEBUG_PORT").unwrap(),
+        sbf_debug_port: std::env::var("SBF_DEBUG_PORT")
+            .map(|port| port.parse::<u16>().ok())
+            .unwrap_or_default(),
     });
 ```

--- a/README.md
+++ b/README.md
@@ -611,6 +611,11 @@ SHA-256 identifier is that files may grow in number, and consumers need a
 deterministic way to evaluate which shared object should be used when
 analyzing the tracing data.
 
+When the `sbpf-debugger` feature is enabled and `SBF_DEBUG_PORT` is set, the
+VM will start a GDB remote stub on the specified TCP port. A debugger client
+can then connect to inspect registers, memory, set
+breakpoints, and step through SBPF execution.
+
 Once enabled register tracing can't be changed afterwards because in nature
 it's baked into the program executables at load time. Yet a user may want a
 more fine-grained control over when register tracing data should be
@@ -640,5 +645,6 @@ mollusk.invocation_inspect_callback =
     Box::new(register_tracing::DefaultRegisterTracingCallback {
         sbf_trace_dir: std::env::var("SBF_TRACE_DIR").unwrap(),
         sbf_trace_disassemble: std::env::var("SBF_TRACE_DISASSEMBLE").is_ok(),
+        sbf_debug_port: std::env::var("SBF_DEBUG_PORT").unwrap(),
     });
 ```

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -37,6 +37,7 @@ register-tracing = [
     "dep:hex",
     "dep:sha2"
 ]
+sbpf-debugger = ["register-tracing", "solana-program-runtime/sbpf-debugger"]
 serde = [
     "dep:serde",
     "mollusk-svm-result/serde",

--- a/harness/src/debugger.rs
+++ b/harness/src/debugger.rs
@@ -25,7 +25,7 @@ pub fn read_reply<R: BufRead>(reader: &mut R) -> std::io::Result<String> {
     let _ = reader.read(&mut cbuf)?;
     let _ = buf.write(&cbuf)?;
     let reply = String::from_utf8_lossy(&buf).to_string();
-    // eprintln!("gdbstub reply: {}", reply);
+
     Ok(reply)
 }
 

--- a/harness/src/debugger.rs
+++ b/harness/src/debugger.rs
@@ -1,0 +1,193 @@
+//! GDB Remote Serial Protocol (RSP) client helpers for the SBPF debugger.
+//!
+//! Provides low-level packet construction, parsing, and convenience wrappers
+//! for communicating with the GDB stub exposed by the SBPF VM when the
+//! `sbpf-debugger` feature is enabled.
+
+use std::{
+    collections::HashMap,
+    io::{BufRead, BufReader, Write},
+    net::{TcpStream, ToSocketAddrs},
+    time::Duration,
+};
+
+/// Reads a single GDB RSP packet from the stream.
+/// Packets are delimited by `#` followed by a 2-character checksum.
+pub fn read_reply<R: BufRead>(reader: &mut R) -> std::io::Result<String> {
+    let mut buf = Vec::new();
+
+    // Read till the # character.
+    reader.read_until(b'#', &mut buf)?;
+    // Then read exactly 2 bytes representing the checksum.
+    let mut cbuf = [0];
+    let _ = reader.read(&mut cbuf)?;
+    let _ = buf.write(&cbuf)?;
+    let _ = reader.read(&mut cbuf)?;
+    let _ = buf.write(&cbuf)?;
+    let reply = String::from_utf8_lossy(&buf).to_string();
+    // eprintln!("gdbstub reply: {}", reply);
+    Ok(reply)
+}
+
+/// Builds a GDB `m` (read memory) command packet for the given address and
+/// size.
+pub fn gdb_read_memory_cmd(addr: u64, size: usize) -> Vec<u8> {
+    let payload = format!("m{addr:x},{size:x}");
+    let checksum: u8 = payload.bytes().fold(0u8, |acc, b| acc.wrapping_add(b));
+    format!("${payload}#{checksum:02x}").into_bytes()
+}
+
+/// Parses a GDB RSP packet payload into raw bytes.
+/// Handles the `+` ack prefix, `$` framing, `O` console output prefix,
+/// `#xx` checksum suffix, and `*` run-length encoding.
+pub fn gdb_parse_packet(input: &str) -> Option<Vec<u8>> {
+    const GDB_RLE_OFFSET: u8 = 29;
+
+    let data = input.strip_prefix('+').unwrap_or(input);
+    let data = data.strip_prefix('$')?;
+    // might be a console output $O..
+    let data = data.strip_prefix('O').unwrap_or(data);
+    let data = data.split('#').next()?;
+
+    let mut hex_str = String::new();
+    let mut chars = data.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '*' {
+            let count_char = chars.next()?;
+            let repeat = (count_char as u8).saturating_sub(GDB_RLE_OFFSET) as usize;
+            let last = hex_str.chars().last()?;
+            for _ in 0..repeat {
+                hex_str.push(last);
+            }
+        } else {
+            hex_str.push(c);
+        }
+    }
+
+    hex::decode(&hex_str).ok()
+}
+
+/// Builds a GDB `p` (read single register) command packet for the given
+/// register number.
+pub fn gdb_read_register_cmd(reg_num: usize) -> Vec<u8> {
+    let payload = format!("p{reg_num:x}");
+    let checksum: u8 = payload.bytes().fold(0u8, |acc, b| acc.wrapping_add(b));
+    format!("${payload}#{checksum:02x}").into_bytes()
+}
+
+/// Reads a contiguous memory region from the stub in fixed-size chunks.
+/// Splits the request to stay within the stub's packet-size limits.
+pub fn stub_read_memory_chunked<R: BufRead, W: Write>(
+    writer: &mut W,
+    reader: &mut R,
+    addr: u64,
+    total_size: usize,
+    chunk_size: usize,
+) -> std::io::Result<Vec<u8>> {
+    let mut result = Vec::with_capacity(total_size);
+    let mut offset = 0;
+
+    while offset < total_size {
+        let size = std::cmp::min(chunk_size, total_size - offset);
+        writer.write_all(&gdb_read_memory_cmd(addr + offset as u64, size))?;
+        writer.flush()?;
+
+        let reply = read_reply(reader)?;
+        let parsed_reply = gdb_parse_packet(&reply).ok_or(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Invalid data",
+        ))?;
+        result.extend_from_slice(&parsed_reply);
+
+        offset += size;
+    }
+
+    Ok(result)
+}
+
+/// Reads a single 64-bit register value from the stub.
+pub fn stub_read_register<R: BufRead, W: Write>(
+    writer: &mut W,
+    reader: &mut R,
+    reg_num: usize,
+) -> std::io::Result<u64> {
+    let cmd = gdb_read_register_cmd(reg_num);
+    writer.write_all(&cmd)?;
+    writer.flush()?;
+    let reply = read_reply(reader)?;
+    let parsed_reply = gdb_parse_packet(&reply).ok_or(std::io::Error::other("invalid packet"))?;
+    let data = parsed_reply
+        .get(..8)
+        .and_then(|s| s.try_into().ok())
+        .ok_or(std::io::Error::other("expected 8 bytes"))?;
+    let reg_value = u64::from_le_bytes(data);
+    Ok(reg_value)
+}
+
+/// Fetches debug metadata from the stub via the `qRcmd,metadata` monitor
+/// command. Returns key-value pairs (e.g. `program_id`, `cpi_level`, `caller`)
+/// that the SBPF runtime passes through the GDB stub.
+pub fn stub_fetch_debug_metadata<R: BufRead, W: Write>(
+    mut reader: &mut R,
+    writer: &mut W,
+) -> Result<HashMap<String, String>, std::io::Error> {
+    // Take advantage of the metadata monitor command in sbpf
+    // to check what the runtime is already passing to us.
+    // (lldb) process plugin packet monitor metadata
+    // "metadata" -> 6d65746164617461
+    writer.write_all(b"$qRcmd,6d65746164617461#9d")?;
+    let reply = read_reply(&mut reader)?;
+    let parsed = gdb_parse_packet(&reply).ok_or(std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        "Can't parse metadata monitor command reply",
+    ))?;
+
+    // Drain the OK following.
+    let reply = read_reply(&mut reader)?;
+    assert_eq!("$OK#9a", reply);
+
+    // We expect a plain text metadata with a newline appended so have it trimmed.
+    let parsed = String::from_utf8_lossy(&parsed).trim_end().to_string();
+    let parsed_map: HashMap<_, _> = parsed
+        .split(';')
+        .filter_map(|e| e.split_once('='))
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+
+    Ok(parsed_map)
+}
+
+/// Sends a `vCont;c` (continue all threads) command and waits for the
+/// program to exit (`W00` — clean exit with status 0).
+pub fn stub_send_continue_command<R: BufRead, W: Write>(
+    mut reader: &mut R,
+    writer: &mut W,
+) -> Result<(), std::io::Error> {
+    writer.write_all(b"$vCont;c:p1.-1#0f")?;
+    let reply = read_reply(&mut reader)?;
+    assert_eq!("+$W00#b7", reply);
+    Ok(())
+}
+
+/// Connects to the GDB stub with retries (100ms apart).
+/// Returns a buffered reader and a writer over the same TCP stream.
+pub fn stub_connect<A: ToSocketAddrs>(
+    stub_addr: A,
+    mut retries: usize,
+) -> Result<(BufReader<TcpStream>, TcpStream), std::io::Error> {
+    let (reader, writer) = loop {
+        retries -= 1;
+        match std::net::TcpStream::connect(&stub_addr) {
+            Err(e) => {
+                if retries == 0 {
+                    return Err(e);
+                }
+                std::thread::sleep(Duration::from_millis(100));
+                continue;
+            }
+            Ok(stream) => break (BufReader::new(stream.try_clone()?), stream),
+        }
+    };
+    Ok((reader, writer))
+}

--- a/harness/src/debugger.rs
+++ b/harness/src/debugger.rs
@@ -177,12 +177,12 @@ pub fn stub_connect<A: ToSocketAddrs>(
     mut retries: usize,
 ) -> Result<(BufReader<TcpStream>, TcpStream), std::io::Error> {
     let (reader, writer) = loop {
-        retries -= 1;
         match std::net::TcpStream::connect(&stub_addr) {
             Err(e) => {
                 if retries == 0 {
                     return Err(e);
                 }
+                retries -= 1;
                 std::thread::sleep(Duration::from_millis(100));
                 continue;
             }

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -564,9 +564,6 @@ pub trait InvocationInspectCallback {
         invoke_context: &InvokeContext,
         register_tracing_enabled: bool,
     );
-
-    fn as_any(&self) -> &dyn std::any::Any;
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 }
 
 #[cfg(feature = "invocation-inspect-callback")]
@@ -574,14 +571,6 @@ pub struct EmptyInvocationInspectCallback;
 
 #[cfg(feature = "invocation-inspect-callback")]
 impl InvocationInspectCallback for EmptyInvocationInspectCallback {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
-
     fn before_invocation(
         &self,
         _: &Mollusk,

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -441,6 +441,8 @@
 
 pub mod account_store;
 mod compile_accounts;
+#[cfg(feature = "sbpf-debugger")]
+pub mod debugger;
 pub mod epoch_stake;
 pub mod file;
 #[cfg(any(feature = "fuzz", feature = "fuzz-fd"))]
@@ -552,7 +554,8 @@ pub trait InvocationInspectCallback {
         program_id: &Pubkey,
         instruction_data: &[u8],
         instruction_accounts: &[InstructionAccount],
-        invoke_context: &InvokeContext,
+        invoke_context: &mut InvokeContext,
+        register_tracing_enabled: bool,
     );
 
     fn after_invocation(
@@ -561,6 +564,9 @@ pub trait InvocationInspectCallback {
         invoke_context: &InvokeContext,
         register_tracing_enabled: bool,
     );
+
+    fn as_any(&self) -> &dyn std::any::Any;
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 }
 
 #[cfg(feature = "invocation-inspect-callback")]
@@ -568,13 +574,22 @@ pub struct EmptyInvocationInspectCallback;
 
 #[cfg(feature = "invocation-inspect-callback")]
 impl InvocationInspectCallback for EmptyInvocationInspectCallback {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn before_invocation(
         &self,
         _: &Mollusk,
         _: &Pubkey,
         _: &[u8],
         _: &[InstructionAccount],
-        _: &InvokeContext,
+        _: &mut InvokeContext,
+        _register_tracing_enabled: bool,
     ) {
     }
 
@@ -1047,7 +1062,8 @@ impl Mollusk {
                     program_id,
                     &compiled_ix.data,
                     &instruction_accounts,
-                    &invoke_context,
+                    &mut invoke_context,
+                    self.enable_register_tracing,
                 );
             }
 

--- a/harness/src/register_tracing.rs
+++ b/harness/src/register_tracing.rs
@@ -251,6 +251,7 @@ pub(crate) fn as_bytes<T>(slice: &[T]) -> &[u8] {
     unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u8, std::mem::size_of_val(slice)) }
 }
 
+/// Returns the SHA-256 hash of the given bytes as a lowercase hex string.
 pub fn compute_hash(slice: &[u8]) -> String {
     hex::encode(Sha256::digest(slice).as_slice())
 }

--- a/harness/src/register_tracing.rs
+++ b/harness/src/register_tracing.rs
@@ -10,10 +10,14 @@ use {
 };
 
 const DEFAULT_PATH: &str = "target/sbf/trace";
+#[cfg(feature = "sbpf-debugger")]
+const DEFAULT_DEBUG_PORT: Option<u16> = None;
 
 pub struct DefaultRegisterTracingCallback {
     pub sbf_trace_dir: String,
     pub sbf_trace_disassemble: bool,
+    #[cfg(feature = "sbpf-debugger")]
+    pub sbf_debug_port: Option<u16>,
 }
 
 impl Default for DefaultRegisterTracingCallback {
@@ -22,6 +26,12 @@ impl Default for DefaultRegisterTracingCallback {
             // User can override default path with `SBF_TRACE_DIR` environment variable.
             sbf_trace_dir: std::env::var("SBF_TRACE_DIR").unwrap_or(DEFAULT_PATH.to_string()),
             sbf_trace_disassemble: std::env::var("SBF_TRACE_DISASSEMBLE").is_ok(),
+            // The port that will be used for debugging.
+            // Will invoke the debugger if set.
+            #[cfg(feature = "sbpf-debugger")]
+            sbf_debug_port: std::env::var("SBF_DEBUG_PORT")
+                .map(|port| port.parse::<u16>().ok())
+                .unwrap_or(DEFAULT_DEBUG_PORT),
         }
     }
 }
@@ -48,7 +58,32 @@ impl DefaultRegisterTracingCallback {
         }
     }
 
-    pub fn handler(
+    pub fn pre_handler(
+        &self,
+        _mollusk: &Mollusk,
+        _program_id: &Pubkey,
+        _instruction_data: &[u8],
+        _instruction_accounts: &[InstructionAccount],
+        _invoke_context: &mut InvokeContext,
+    ) {
+        #[cfg(feature = "sbpf-debugger")]
+        {
+            if let Some(debug_port) = self.sbf_debug_port {
+                // Persist SHA-256 mapping for every ELF account.
+                // We need them later to judge what symbol object to
+                // load in the debugger client.
+                let _ = self.elf_accounts_to_sha256(
+                    _mollusk,
+                    _program_id,
+                    _instruction_accounts,
+                    _invoke_context,
+                );
+                _invoke_context.debug_port = Some(debug_port);
+            }
+        }
+    }
+
+    pub fn post_handler(
         &self,
         mollusk: &Mollusk,
         instruction_context: InstructionContext,
@@ -60,6 +95,9 @@ impl DefaultRegisterTracingCallback {
             return Ok(());
         }
 
+        // Get program_id.
+        let program_id = instruction_context.get_program_key()?;
+
         let current_dir = std::env::current_dir()?;
         let sbf_trace_dir = current_dir.join(&self.sbf_trace_dir);
         std::fs::create_dir_all(&sbf_trace_dir)?;
@@ -69,9 +107,6 @@ impl DefaultRegisterTracingCallback {
         let mut regs_file = File::create(base_fname.with_extension("regs"))?;
         let mut insns_file = File::create(base_fname.with_extension("insns"))?;
         let mut program_id_file = File::create(base_fname.with_extension("program_id"))?;
-
-        // Get program_id.
-        let program_id = instruction_context.get_program_key()?;
 
         // Persist a full trace disassembly if requested.
         if self.sbf_trace_disassemble {
@@ -110,17 +145,91 @@ impl DefaultRegisterTracingCallback {
 
         Ok(())
     }
+
+    /// Persists a mapping of program IDs to SHA-256 hashes of their ELF bytes.
+    /// Includes the top-level program and any instruction accounts that are
+    /// programs in the cache. This allows a debugger client to resolve which
+    /// .so to load for symbol information.
+    pub fn elf_accounts_to_sha256(
+        &self,
+        mollusk: &Mollusk,
+        program_id: &Pubkey,
+        instruction_accounts: &[InstructionAccount],
+        invoke_context: &InvokeContext,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let current_dir = std::env::current_dir()?;
+        let sbf_trace_dir = current_dir.join(&self.sbf_trace_dir);
+        std::fs::create_dir_all(&sbf_trace_dir)?;
+        let base_fname = sbf_trace_dir.join("program_ids");
+        let mut program_ids_file = File::create(base_fname.with_extension("map"))?;
+
+        // Collect the top-level program and all instruction account pubkeys.
+        // CPI targets appear as instruction accounts, so we include them to
+        // let the debugger resolve their ELF symbols.
+        let mut maybe_elf_program_ids = std::collections::HashSet::new();
+
+        maybe_elf_program_ids.insert(program_id);
+        instruction_accounts
+            .iter()
+            .flat_map(|ia| {
+                invoke_context
+                    .transaction_context
+                    .get_key_of_account_at_index(ia.index_in_transaction)
+            })
+            .for_each(|pubkey| {
+                maybe_elf_program_ids.insert(pubkey);
+            });
+
+        // Only write entries for pubkeys that actually have ELF bytes in the cache.
+        maybe_elf_program_ids
+            .iter()
+            .for_each(|maybe_elf_program_id| {
+                if let Some(elf_data) = mollusk
+                    .program_cache
+                    .get_program_elf_bytes(maybe_elf_program_id)
+                {
+                    let _ = program_ids_file.write(
+                        format!(
+                            "{}={}\n",
+                            maybe_elf_program_id,
+                            compute_hash(elf_data.as_slice())
+                        )
+                        .as_bytes(),
+                    );
+                }
+            });
+
+        Ok(())
+    }
 }
 
 impl InvocationInspectCallback for DefaultRegisterTracingCallback {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn before_invocation(
         &self,
-        _: &Mollusk,
-        _: &Pubkey,
-        _: &[u8],
-        _: &[InstructionAccount],
-        _: &InvokeContext,
+        mollusk: &Mollusk,
+        program_id: &Pubkey,
+        instruction_data: &[u8],
+        instruction_accounts: &[InstructionAccount],
+        invoke_context: &mut InvokeContext,
+        register_tracing_enabled: bool,
     ) {
+        if register_tracing_enabled {
+            self.pre_handler(
+                mollusk,
+                program_id,
+                instruction_data,
+                instruction_accounts,
+                invoke_context,
+            );
+        }
     }
 
     fn after_invocation(
@@ -136,9 +245,9 @@ impl InvocationInspectCallback for DefaultRegisterTracingCallback {
                   executable: &Executable,
                   register_trace: RegisterTrace| {
                     if let Err(e) =
-                        self.handler(mollusk, instruction_context, executable, register_trace)
+                        self.post_handler(mollusk, instruction_context, executable, register_trace)
                     {
-                        eprintln!("Error collecting the register tracing: {}", e);
+                        eprintln!("Error collecting the register tracing: {e}");
                     }
                 },
             );
@@ -150,6 +259,6 @@ pub(crate) fn as_bytes<T>(slice: &[T]) -> &[u8] {
     unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u8, std::mem::size_of_val(slice)) }
 }
 
-fn compute_hash(slice: &[u8]) -> String {
+pub fn compute_hash(slice: &[u8]) -> String {
     hex::encode(Sha256::digest(slice).as_slice())
 }

--- a/harness/src/register_tracing.rs
+++ b/harness/src/register_tracing.rs
@@ -10,8 +10,6 @@ use {
 };
 
 const DEFAULT_PATH: &str = "target/sbf/trace";
-#[cfg(feature = "sbpf-debugger")]
-const DEFAULT_DEBUG_PORT: Option<u16> = None;
 
 pub struct DefaultRegisterTracingCallback {
     pub sbf_trace_dir: String,
@@ -31,7 +29,7 @@ impl Default for DefaultRegisterTracingCallback {
             #[cfg(feature = "sbpf-debugger")]
             sbf_debug_port: std::env::var("SBF_DEBUG_PORT")
                 .map(|port| port.parse::<u16>().ok())
-                .unwrap_or(DEFAULT_DEBUG_PORT),
+                .unwrap_or_default(),
         }
     }
 }
@@ -72,12 +70,14 @@ impl DefaultRegisterTracingCallback {
                 // Persist SHA-256 mapping for every ELF account.
                 // We need them later to judge what symbol object to
                 // load in the debugger client.
-                let _ = self.elf_accounts_to_sha256(
+                if let Err(e) = self.elf_accounts_to_sha256(
                     _mollusk,
                     _program_id,
                     _instruction_accounts,
                     _invoke_context,
-                );
+                ) {
+                    eprintln!("Failed to persist the ELF SHA-256 mappings: {e}");
+                }
                 _invoke_context.debug_port = Some(debug_port);
             }
         }
@@ -204,14 +204,6 @@ impl DefaultRegisterTracingCallback {
 }
 
 impl InvocationInspectCallback for DefaultRegisterTracingCallback {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
-
     fn before_invocation(
         &self,
         mollusk: &Mollusk,

--- a/harness/src/register_tracing.rs
+++ b/harness/src/register_tracing.rs
@@ -56,13 +56,13 @@ impl DefaultRegisterTracingCallback {
         }
     }
 
+    #[cfg_attr(not(feature = "sbpf-debugger"), expect(unused_variables))]
     pub fn pre_handler(
         &self,
-        _mollusk: &Mollusk,
-        _program_id: &Pubkey,
-        _instruction_data: &[u8],
-        _instruction_accounts: &[InstructionAccount],
-        _invoke_context: &mut InvokeContext,
+        mollusk: &Mollusk,
+        program_id: &Pubkey,
+        instruction_accounts: &[InstructionAccount],
+        invoke_context: &mut InvokeContext,
     ) {
         #[cfg(feature = "sbpf-debugger")]
         {
@@ -71,14 +71,14 @@ impl DefaultRegisterTracingCallback {
                 // We need them later to judge what symbol object to
                 // load in the debugger client.
                 if let Err(e) = self.elf_accounts_to_sha256(
-                    _mollusk,
-                    _program_id,
-                    _instruction_accounts,
-                    _invoke_context,
+                    mollusk,
+                    program_id,
+                    instruction_accounts,
+                    invoke_context,
                 ) {
                     eprintln!("Failed to persist the ELF SHA-256 mappings: {e}");
                 }
-                _invoke_context.debug_port = Some(debug_port);
+                invoke_context.debug_port = Some(debug_port);
             }
         }
     }
@@ -208,19 +208,13 @@ impl InvocationInspectCallback for DefaultRegisterTracingCallback {
         &self,
         mollusk: &Mollusk,
         program_id: &Pubkey,
-        instruction_data: &[u8],
+        _instruction_data: &[u8],
         instruction_accounts: &[InstructionAccount],
         invoke_context: &mut InvokeContext,
         register_tracing_enabled: bool,
     ) {
         if register_tracing_enabled {
-            self.pre_handler(
-                mollusk,
-                program_id,
-                instruction_data,
-                instruction_accounts,
-                invoke_context,
-            );
+            self.pre_handler(mollusk, program_id, instruction_accounts, invoke_context);
         }
     }
 

--- a/harness/tests/register_tracing.rs
+++ b/harness/tests/register_tracing.rs
@@ -337,19 +337,6 @@ fn test_debugger() {
                 stub_read_memory_chunked(&mut writer, &mut reader, data_addr, data_len, 1024)?;
             assert!(instruction.data == data);
 
-            // Don't use this approach as it depends on the ABI.
-            // // Verify the program_id reported by the gdbstub matches the one we're
-            // // debugging.
-            // let mut reply = stub_read_memory_chunked(
-            //     &mut writer,
-            //     &mut reader,
-            //     0x400000000,     // The input buffer of the program starts from here.
-            //     1 * 1024 * 1024, // Read 1MB just in case.
-            //     1024,            // Read in chunks of 1024 bytes.
-            // )?;
-            // let (deserialized_program_id, _, _) =
-            //     unsafe { solana_program_entrypoint::deserialize(reply.as_mut_ptr()) };
-            // assert_eq!(program_id, *deserialized_program_id);
             let parsed_map = stub_fetch_debug_metadata(&mut reader, &mut writer)?;
 
             // After parsing the reply check the runtime has passed to us the

--- a/harness/tests/register_tracing.rs
+++ b/harness/tests/register_tracing.rs
@@ -62,13 +62,22 @@ fn test_custom_register_tracing_callback() {
     }
 
     impl InvocationInspectCallback for CustomRegisterTracingCallback {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            self
+        }
+
         fn before_invocation(
             &self,
             _: &Mollusk,
             _: &Pubkey,
             _: &[u8],
             _: &[InstructionAccount],
-            _: &InvokeContext,
+            _: &mut InvokeContext,
+            _register_tracing_enabled: bool,
         ) {
         }
 
@@ -80,6 +89,8 @@ fn test_custom_register_tracing_callback() {
         ) {
             // Only process traces if register tracing was enabled.
             if register_tracing_enabled {
+                use solana_transaction_context::instruction::InstructionContext;
+
                 invoke_context.iterate_vm_traces(
                     &|instruction_context: InstructionContext,
                       executable: &Executable,
@@ -87,7 +98,7 @@ fn test_custom_register_tracing_callback() {
                         if let Err(e) =
                             self.handler(instruction_context, executable, register_trace)
                         {
-                            eprintln!("Error collecting the register tracing: {}", e);
+                            eprintln!("Error collecting the register tracing: {e}");
                         }
                     },
                 );
@@ -209,5 +220,202 @@ fn test_custom_register_tracing_callback() {
             collected_data.executed_jump_instructions_count
                 == executed_jump_instruction_count_from_phase1
         );
+    }
+}
+
+#[cfg(feature = "sbpf-debugger")]
+#[cfg(test)]
+mod debugger_tests {
+    use {
+        mollusk_svm::{
+            debugger::{
+                stub_connect, stub_fetch_debug_metadata, stub_read_memory_chunked,
+                stub_read_register, stub_send_continue_command,
+            },
+            program::create_program_account_loader_v3,
+            register_tracing::{compute_hash, DefaultRegisterTracingCallback},
+            Mollusk,
+        },
+        solana_account::Account,
+        solana_message::{AccountMeta, Instruction},
+        solana_pubkey::Pubkey,
+        std::net::{IpAddr, Ipv4Addr, SocketAddr},
+    };
+
+    #[test]
+    fn test_debugger() {
+        const SBF_DEBUG_PORT: u16 = 21212;
+        const STUB_ADDR: SocketAddr =
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), SBF_DEBUG_PORT);
+        const STUB_CONNECT_RETRIES: usize = 30;
+
+        std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+        std::env::set_var("SBF_DEBUG_PORT", SBF_DEBUG_PORT.to_string());
+
+        let program_id = Pubkey::new_unique();
+        let cpi_target_program_id = Pubkey::new_unique();
+        // Use new_debuggable with register tracing enabled.
+        let mut mollusk = Mollusk::new_debuggable(
+            &program_id,
+            "test_program_primary",
+            /* enable_register_tracing */ true,
+        );
+
+        mollusk.add_program_with_loader(
+            &cpi_target_program_id,
+            "test_program_cpi_target",
+            &mollusk_svm::program::loader_keys::LOADER_V3,
+        );
+        mollusk.feature_set.activate(
+            &agave_feature_set::provide_instruction_data_offset_in_vm_r2::id(),
+            0,
+        );
+
+        let data = &[1, 2, 3, 4, 5];
+        let space = data.len();
+        let lamports = mollusk.sysvars.rent.minimum_balance(space);
+
+        let key = Pubkey::new_unique();
+        let account = Account::new(lamports, space, &cpi_target_program_id);
+        let (instruction, instruction_data_len) = {
+            let mut instruction_data = vec![4];
+            instruction_data.extend_from_slice(cpi_target_program_id.as_ref());
+            instruction_data.extend_from_slice(data);
+            (
+                Instruction::new_with_bytes(
+                    program_id,
+                    &instruction_data,
+                    vec![
+                        AccountMeta::new(key, true),
+                        AccountMeta::new_readonly(cpi_target_program_id, false),
+                    ],
+                ),
+                instruction_data.len(),
+            )
+        };
+
+        let accounts = &[
+            (key, account.clone()),
+            (
+                cpi_target_program_id,
+                create_program_account_loader_v3(&cpi_target_program_id),
+            ),
+        ];
+
+        let tracing_callback: &DefaultRegisterTracingCallback = mollusk
+            .invocation_inspect_callback
+            .as_any()
+            .downcast_ref()
+            .unwrap();
+
+        let program_id_file = std::path::PathBuf::from(&tracing_callback.sbf_trace_dir)
+            .join("program_ids")
+            .with_extension("map");
+
+        // This is the expected program IDs <-> SHA-256 mapping.
+        let expected_program_ids = format!(
+            "{}={}\n{}={}\n",
+            program_id,
+            compute_hash(
+                mollusk
+                    .program_cache
+                    .get_program_elf_bytes(&program_id)
+                    .unwrap()
+                    .as_slice()
+            ),
+            cpi_target_program_id,
+            compute_hash(
+                mollusk
+                    .program_cache
+                    .get_program_elf_bytes(&cpi_target_program_id)
+                    .unwrap()
+                    .as_slice()
+            )
+        );
+
+        // Execute the instruction that does a CPI.
+        // It's supposed to hang waiting for a TCP connection on the debugger port.
+        std::thread::scope(|s| {
+            let client_jh = s.spawn(|| -> Result<(), std::io::Error> {
+                // Connect to the debugger stub.
+                let (mut reader, mut writer) = stub_connect(STUB_ADDR, STUB_CONNECT_RETRIES)?;
+
+                // Check r2 - it should point to the instruction data whereas the length is 8
+                // bytes prior to it.
+                let data_addr = stub_read_register(&mut writer, &mut reader, 2)?;
+                let data_len = u64::from_le_bytes(
+                    stub_read_memory_chunked(&mut writer, &mut reader, data_addr - 8, 8, 1024)?
+                        .try_into()
+                        .map_err(|_| std::io::Error::other("expected 8 bytes"))?,
+                ) as usize;
+                assert!(instruction_data_len == data_len);
+                let data =
+                    stub_read_memory_chunked(&mut writer, &mut reader, data_addr, data_len, 1024)?;
+                assert!(instruction.data == data);
+
+                // Don't use this approach as it depends on the ABI.
+                // // Verify the program_id reported by the gdbstub matches the one we're
+                // // debugging.
+                // let mut reply = stub_read_memory_chunked(
+                //     &mut writer,
+                //     &mut reader,
+                //     0x400000000,     // The input buffer of the program starts from here.
+                //     1 * 1024 * 1024, // Read 1MB just in case.
+                //     1024,            // Read in chunks of 1024 bytes.
+                // )?;
+                // let (deserialized_program_id, _, _) =
+                //     unsafe { solana_program_entrypoint::deserialize(reply.as_mut_ptr()) };
+                // assert_eq!(program_id, *deserialized_program_id);
+                let parsed_map = stub_fetch_debug_metadata(&mut reader, &mut writer)?;
+
+                // After parsing the reply check the runtime has passed to us the
+                // expected program_id in the metadata.
+                assert!(
+                    parsed_map.get("program_id") == Some(&program_id.to_string())
+                        && parsed_map.get("cpi_level") == Some(&"0".to_string())
+                        && parsed_map.get("caller") == Some(&"none".to_string())
+                );
+
+                // Fire the CPI handling prior to issuing the continue command.
+                let cpi_client_jh = s.spawn(|| -> Result<(), std::io::Error> {
+                    // The CPI means we have another gdb stub instantiated and listening.
+                    let (mut reader, mut writer) = stub_connect(STUB_ADDR, STUB_CONNECT_RETRIES)?;
+
+                    let parsed_map = stub_fetch_debug_metadata(&mut reader, &mut writer)?;
+
+                    // Check the CPI callee and caller and level.
+                    assert!(
+                        parsed_map.get("program_id") == Some(&cpi_target_program_id.to_string())
+                            && parsed_map.get("cpi_level") == Some(&"1".to_string())
+                            && parsed_map.get("caller") == Some(&program_id.to_string())
+                    );
+
+                    // Issue the continue command.
+                    stub_send_continue_command(&mut reader, &mut writer)?;
+
+                    Ok(())
+                });
+
+                // Issue the continue command.
+                stub_send_continue_command(&mut reader, &mut writer)?;
+
+                cpi_client_jh.join().unwrap().expect("cpi client error");
+
+                Ok(())
+            });
+
+            // Processing...
+            let _ = mollusk.process_instruction(&instruction, accounts);
+
+            client_jh.join().unwrap().expect("client error");
+        });
+
+        // Check the program_ids <-> elf sha256 mapping table.
+        let read_program_ids = std::fs::read_to_string(&program_id_file).unwrap();
+        let mut read_lines: Vec<&str> = read_program_ids.lines().collect();
+        let mut expected_lines: Vec<&str> = expected_program_ids.lines().collect();
+        read_lines.sort();
+        expected_lines.sort();
+        assert_eq!(read_lines, expected_lines);
     }
 }

--- a/harness/tests/register_tracing.rs
+++ b/harness/tests/register_tracing.rs
@@ -233,7 +233,7 @@ fn test_debugger() {
     const STUB_ADDR: SocketAddr =
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), SBF_DEBUG_PORT);
     const STUB_CONNECT_RETRIES: usize = 30;
-    const SBF_TRACE_DIR: &'static str = "target/sbf/trace";
+    const SBF_TRACE_DIR: &str = "target/sbf/trace";
 
     std::env::set_var("SBF_OUT_DIR", "../target/deploy");
 

--- a/harness/tests/register_tracing.rs
+++ b/harness/tests/register_tracing.rs
@@ -1,18 +1,31 @@
+#[cfg(feature = "sbpf-debugger")]
+use {
+    mollusk_svm::{
+        debugger::{
+            stub_connect, stub_fetch_debug_metadata, stub_read_memory_chunked, stub_read_register,
+            stub_send_continue_command,
+        },
+        program::create_program_account_loader_v3,
+        register_tracing::compute_hash,
+    },
+    std::net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+#[cfg(feature = "register-tracing")]
+use {
+    mollusk_svm::{InvocationInspectCallback, Mollusk},
+    solana_account::Account,
+    solana_instruction::{AccountMeta, Instruction},
+    solana_program_runtime::invoke_context::{Executable, InvokeContext, RegisterTrace},
+    solana_pubkey::Pubkey,
+    solana_transaction_context::{
+        instruction::InstructionContext, instruction_accounts::InstructionAccount,
+    },
+    std::{cell::RefCell, collections::HashMap, rc::Rc},
+};
+
 #[cfg(feature = "register-tracing")]
 #[test]
 fn test_custom_register_tracing_callback() {
-    use {
-        mollusk_svm::{InvocationInspectCallback, Mollusk},
-        solana_account::Account,
-        solana_instruction::{AccountMeta, Instruction},
-        solana_program_runtime::invoke_context::{Executable, InvokeContext, RegisterTrace},
-        solana_pubkey::Pubkey,
-        solana_transaction_context::{
-            instruction::InstructionContext, instruction_accounts::InstructionAccount,
-        },
-        std::{cell::RefCell, collections::HashMap, rc::Rc},
-    };
-
     struct TracingData {
         program_id: Pubkey,
         executed_jump_instructions_count: usize,
@@ -62,14 +75,6 @@ fn test_custom_register_tracing_callback() {
     }
 
     impl InvocationInspectCallback for CustomRegisterTracingCallback {
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
-
-        fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-            self
-        }
-
         fn before_invocation(
             &self,
             _: &Mollusk,
@@ -89,8 +94,6 @@ fn test_custom_register_tracing_callback() {
         ) {
             // Only process traces if register tracing was enabled.
             if register_tracing_enabled {
-                use solana_transaction_context::instruction::InstructionContext;
-
                 invoke_context.iterate_vm_traces(
                     &|instruction_context: InstructionContext,
                       executable: &Executable,
@@ -224,198 +227,175 @@ fn test_custom_register_tracing_callback() {
 }
 
 #[cfg(feature = "sbpf-debugger")]
-#[cfg(test)]
-mod debugger_tests {
-    use {
-        mollusk_svm::{
-            debugger::{
-                stub_connect, stub_fetch_debug_metadata, stub_read_memory_chunked,
-                stub_read_register, stub_send_continue_command,
-            },
-            program::create_program_account_loader_v3,
-            register_tracing::{compute_hash, DefaultRegisterTracingCallback},
-            Mollusk,
-        },
-        solana_account::Account,
-        solana_message::{AccountMeta, Instruction},
-        solana_pubkey::Pubkey,
-        std::net::{IpAddr, Ipv4Addr, SocketAddr},
+#[test]
+fn test_debugger() {
+    const SBF_DEBUG_PORT: u16 = 21212;
+    const STUB_ADDR: SocketAddr =
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), SBF_DEBUG_PORT);
+    const STUB_CONNECT_RETRIES: usize = 30;
+    const SBF_TRACE_DIR: &'static str = "target/sbf/trace";
+
+    std::env::set_var("SBF_TRACE_DIR", SBF_TRACE_DIR.to_string());
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+    std::env::set_var("SBF_DEBUG_PORT", SBF_DEBUG_PORT.to_string());
+
+    let program_id = Pubkey::new_unique();
+    let cpi_target_program_id = Pubkey::new_unique();
+    // Use new_debuggable with register tracing enabled.
+    let mut mollusk = Mollusk::new_debuggable(
+        &program_id,
+        "test_program_primary",
+        /* enable_register_tracing */ true,
+    );
+
+    mollusk.add_program_with_loader(
+        &cpi_target_program_id,
+        "test_program_cpi_target",
+        &mollusk_svm::program::loader_keys::LOADER_V3,
+    );
+    mollusk.feature_set.activate(
+        &agave_feature_set::provide_instruction_data_offset_in_vm_r2::id(),
+        0,
+    );
+
+    let data = &[1, 2, 3, 4, 5];
+    let space = data.len();
+    let lamports = mollusk.sysvars.rent.minimum_balance(space);
+
+    let key = Pubkey::new_unique();
+    let account = Account::new(lamports, space, &cpi_target_program_id);
+    let (instruction, instruction_data_len) = {
+        let mut instruction_data = vec![4];
+        instruction_data.extend_from_slice(cpi_target_program_id.as_ref());
+        instruction_data.extend_from_slice(data);
+        (
+            Instruction::new_with_bytes(
+                program_id,
+                &instruction_data,
+                vec![
+                    AccountMeta::new(key, true),
+                    AccountMeta::new_readonly(cpi_target_program_id, false),
+                ],
+            ),
+            instruction_data.len(),
+        )
     };
 
-    #[test]
-    fn test_debugger() {
-        const SBF_DEBUG_PORT: u16 = 21212;
-        const STUB_ADDR: SocketAddr =
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), SBF_DEBUG_PORT);
-        const STUB_CONNECT_RETRIES: usize = 30;
-
-        std::env::set_var("SBF_OUT_DIR", "../target/deploy");
-        std::env::set_var("SBF_DEBUG_PORT", SBF_DEBUG_PORT.to_string());
-
-        let program_id = Pubkey::new_unique();
-        let cpi_target_program_id = Pubkey::new_unique();
-        // Use new_debuggable with register tracing enabled.
-        let mut mollusk = Mollusk::new_debuggable(
-            &program_id,
-            "test_program_primary",
-            /* enable_register_tracing */ true,
-        );
-
-        mollusk.add_program_with_loader(
-            &cpi_target_program_id,
-            "test_program_cpi_target",
-            &mollusk_svm::program::loader_keys::LOADER_V3,
-        );
-        mollusk.feature_set.activate(
-            &agave_feature_set::provide_instruction_data_offset_in_vm_r2::id(),
-            0,
-        );
-
-        let data = &[1, 2, 3, 4, 5];
-        let space = data.len();
-        let lamports = mollusk.sysvars.rent.minimum_balance(space);
-
-        let key = Pubkey::new_unique();
-        let account = Account::new(lamports, space, &cpi_target_program_id);
-        let (instruction, instruction_data_len) = {
-            let mut instruction_data = vec![4];
-            instruction_data.extend_from_slice(cpi_target_program_id.as_ref());
-            instruction_data.extend_from_slice(data);
-            (
-                Instruction::new_with_bytes(
-                    program_id,
-                    &instruction_data,
-                    vec![
-                        AccountMeta::new(key, true),
-                        AccountMeta::new_readonly(cpi_target_program_id, false),
-                    ],
-                ),
-                instruction_data.len(),
-            )
-        };
-
-        let accounts = &[
-            (key, account.clone()),
-            (
-                cpi_target_program_id,
-                create_program_account_loader_v3(&cpi_target_program_id),
-            ),
-        ];
-
-        let tracing_callback: &DefaultRegisterTracingCallback = mollusk
-            .invocation_inspect_callback
-            .as_any()
-            .downcast_ref()
-            .unwrap();
-
-        let program_id_file = std::path::PathBuf::from(&tracing_callback.sbf_trace_dir)
-            .join("program_ids")
-            .with_extension("map");
-
-        // This is the expected program IDs <-> SHA-256 mapping.
-        let expected_program_ids = format!(
-            "{}={}\n{}={}\n",
-            program_id,
-            compute_hash(
-                mollusk
-                    .program_cache
-                    .get_program_elf_bytes(&program_id)
-                    .unwrap()
-                    .as_slice()
-            ),
+    let accounts = &[
+        (key, account.clone()),
+        (
             cpi_target_program_id,
-            compute_hash(
-                mollusk
-                    .program_cache
-                    .get_program_elf_bytes(&cpi_target_program_id)
-                    .unwrap()
-                    .as_slice()
-            )
-        );
+            create_program_account_loader_v3(&cpi_target_program_id),
+        ),
+    ];
 
-        // Execute the instruction that does a CPI.
-        // It's supposed to hang waiting for a TCP connection on the debugger port.
-        std::thread::scope(|s| {
-            let client_jh = s.spawn(|| -> Result<(), std::io::Error> {
-                // Connect to the debugger stub.
+    let program_id_file = std::path::PathBuf::from(SBF_TRACE_DIR)
+        .join("program_ids")
+        .with_extension("map");
+
+    // This is the expected program IDs <-> SHA-256 mapping.
+    let expected_program_ids = format!(
+        "{}={}\n{}={}\n",
+        program_id,
+        compute_hash(
+            mollusk
+                .program_cache
+                .get_program_elf_bytes(&program_id)
+                .unwrap()
+                .as_slice()
+        ),
+        cpi_target_program_id,
+        compute_hash(
+            mollusk
+                .program_cache
+                .get_program_elf_bytes(&cpi_target_program_id)
+                .unwrap()
+                .as_slice()
+        )
+    );
+
+    // Execute the instruction that does a CPI.
+    // It's supposed to hang waiting for a TCP connection on the debugger port.
+    std::thread::scope(|s| {
+        let client_jh = s.spawn(|| -> Result<(), std::io::Error> {
+            // Connect to the debugger stub.
+            let (mut reader, mut writer) = stub_connect(STUB_ADDR, STUB_CONNECT_RETRIES)?;
+
+            // Check r2 - it should point to the instruction data whereas the length is 8
+            // bytes prior to it.
+            let data_addr = stub_read_register(&mut writer, &mut reader, 2)?;
+            let data_len = u64::from_le_bytes(
+                stub_read_memory_chunked(&mut writer, &mut reader, data_addr - 8, 8, 1024)?
+                    .try_into()
+                    .map_err(|_| std::io::Error::other("expected 8 bytes"))?,
+            ) as usize;
+            assert!(instruction_data_len == data_len);
+            let data =
+                stub_read_memory_chunked(&mut writer, &mut reader, data_addr, data_len, 1024)?;
+            assert!(instruction.data == data);
+
+            // Don't use this approach as it depends on the ABI.
+            // // Verify the program_id reported by the gdbstub matches the one we're
+            // // debugging.
+            // let mut reply = stub_read_memory_chunked(
+            //     &mut writer,
+            //     &mut reader,
+            //     0x400000000,     // The input buffer of the program starts from here.
+            //     1 * 1024 * 1024, // Read 1MB just in case.
+            //     1024,            // Read in chunks of 1024 bytes.
+            // )?;
+            // let (deserialized_program_id, _, _) =
+            //     unsafe { solana_program_entrypoint::deserialize(reply.as_mut_ptr()) };
+            // assert_eq!(program_id, *deserialized_program_id);
+            let parsed_map = stub_fetch_debug_metadata(&mut reader, &mut writer)?;
+
+            // After parsing the reply check the runtime has passed to us the
+            // expected program_id in the metadata.
+            assert!(
+                parsed_map.get("program_id") == Some(&program_id.to_string())
+                    && parsed_map.get("cpi_level") == Some(&"0".to_string())
+                    && parsed_map.get("caller") == Some(&"none".to_string())
+            );
+
+            // Fire the CPI handling prior to issuing the continue command.
+            let cpi_client_jh = s.spawn(|| -> Result<(), std::io::Error> {
+                // The CPI means we have another gdb stub instantiated and listening.
                 let (mut reader, mut writer) = stub_connect(STUB_ADDR, STUB_CONNECT_RETRIES)?;
 
-                // Check r2 - it should point to the instruction data whereas the length is 8
-                // bytes prior to it.
-                let data_addr = stub_read_register(&mut writer, &mut reader, 2)?;
-                let data_len = u64::from_le_bytes(
-                    stub_read_memory_chunked(&mut writer, &mut reader, data_addr - 8, 8, 1024)?
-                        .try_into()
-                        .map_err(|_| std::io::Error::other("expected 8 bytes"))?,
-                ) as usize;
-                assert!(instruction_data_len == data_len);
-                let data =
-                    stub_read_memory_chunked(&mut writer, &mut reader, data_addr, data_len, 1024)?;
-                assert!(instruction.data == data);
-
-                // Don't use this approach as it depends on the ABI.
-                // // Verify the program_id reported by the gdbstub matches the one we're
-                // // debugging.
-                // let mut reply = stub_read_memory_chunked(
-                //     &mut writer,
-                //     &mut reader,
-                //     0x400000000,     // The input buffer of the program starts from here.
-                //     1 * 1024 * 1024, // Read 1MB just in case.
-                //     1024,            // Read in chunks of 1024 bytes.
-                // )?;
-                // let (deserialized_program_id, _, _) =
-                //     unsafe { solana_program_entrypoint::deserialize(reply.as_mut_ptr()) };
-                // assert_eq!(program_id, *deserialized_program_id);
                 let parsed_map = stub_fetch_debug_metadata(&mut reader, &mut writer)?;
 
-                // After parsing the reply check the runtime has passed to us the
-                // expected program_id in the metadata.
+                // Check the CPI callee and caller and level.
                 assert!(
-                    parsed_map.get("program_id") == Some(&program_id.to_string())
-                        && parsed_map.get("cpi_level") == Some(&"0".to_string())
-                        && parsed_map.get("caller") == Some(&"none".to_string())
+                    parsed_map.get("program_id") == Some(&cpi_target_program_id.to_string())
+                        && parsed_map.get("cpi_level") == Some(&"1".to_string())
+                        && parsed_map.get("caller") == Some(&program_id.to_string())
                 );
-
-                // Fire the CPI handling prior to issuing the continue command.
-                let cpi_client_jh = s.spawn(|| -> Result<(), std::io::Error> {
-                    // The CPI means we have another gdb stub instantiated and listening.
-                    let (mut reader, mut writer) = stub_connect(STUB_ADDR, STUB_CONNECT_RETRIES)?;
-
-                    let parsed_map = stub_fetch_debug_metadata(&mut reader, &mut writer)?;
-
-                    // Check the CPI callee and caller and level.
-                    assert!(
-                        parsed_map.get("program_id") == Some(&cpi_target_program_id.to_string())
-                            && parsed_map.get("cpi_level") == Some(&"1".to_string())
-                            && parsed_map.get("caller") == Some(&program_id.to_string())
-                    );
-
-                    // Issue the continue command.
-                    stub_send_continue_command(&mut reader, &mut writer)?;
-
-                    Ok(())
-                });
 
                 // Issue the continue command.
                 stub_send_continue_command(&mut reader, &mut writer)?;
 
-                cpi_client_jh.join().unwrap().expect("cpi client error");
-
                 Ok(())
             });
 
-            // Processing...
-            let _ = mollusk.process_instruction(&instruction, accounts);
+            // Issue the continue command.
+            stub_send_continue_command(&mut reader, &mut writer)?;
 
-            client_jh.join().unwrap().expect("client error");
+            cpi_client_jh.join().unwrap().expect("cpi client error");
+
+            Ok(())
         });
 
-        // Check the program_ids <-> elf sha256 mapping table.
-        let read_program_ids = std::fs::read_to_string(&program_id_file).unwrap();
-        let mut read_lines: Vec<&str> = read_program_ids.lines().collect();
-        let mut expected_lines: Vec<&str> = expected_program_ids.lines().collect();
-        read_lines.sort();
-        expected_lines.sort();
-        assert_eq!(read_lines, expected_lines);
-    }
+        // Processing...
+        let _ = mollusk.process_instruction(&instruction, accounts);
+
+        client_jh.join().unwrap().expect("client error");
+    });
+
+    // Check the program_ids <-> elf sha256 mapping table.
+    let read_program_ids = std::fs::read_to_string(&program_id_file).unwrap();
+    let mut read_lines: Vec<&str> = read_program_ids.lines().collect();
+    let mut expected_lines: Vec<&str> = expected_program_ids.lines().collect();
+    read_lines.sort();
+    expected_lines.sort();
+    assert_eq!(read_lines, expected_lines);
 }

--- a/harness/tests/register_tracing.rs
+++ b/harness/tests/register_tracing.rs
@@ -6,7 +6,7 @@ use {
             stub_send_continue_command,
         },
         program::create_program_account_loader_v3,
-        register_tracing::compute_hash,
+        register_tracing::{compute_hash, DefaultRegisterTracingCallback},
     },
     std::net::{IpAddr, Ipv4Addr, SocketAddr},
 };
@@ -235,9 +235,7 @@ fn test_debugger() {
     const STUB_CONNECT_RETRIES: usize = 30;
     const SBF_TRACE_DIR: &'static str = "target/sbf/trace";
 
-    std::env::set_var("SBF_TRACE_DIR", SBF_TRACE_DIR.to_string());
     std::env::set_var("SBF_OUT_DIR", "../target/deploy");
-    std::env::set_var("SBF_DEBUG_PORT", SBF_DEBUG_PORT.to_string());
 
     let program_id = Pubkey::new_unique();
     let cpi_target_program_id = Pubkey::new_unique();
@@ -247,6 +245,11 @@ fn test_debugger() {
         "test_program_primary",
         /* enable_register_tracing */ true,
     );
+    mollusk.invocation_inspect_callback = Box::new(DefaultRegisterTracingCallback {
+        sbf_trace_dir: SBF_TRACE_DIR.into(),
+        sbf_trace_disassemble: false,
+        sbf_debug_port: SBF_DEBUG_PORT.into(),
+    });
 
     mollusk.add_program_with_loader(
         &cpi_target_program_id,


### PR DESCRIPTION
**The problem**

There is no Mollusk integration with the SBPF debugger, meaning users couldn't interactively debug program execution from within Mollusk tests.

**What's changed**

- Add `sbpf-debugger` feature that starts a GDB remote stub on a configurable TCP port (`SBF_DEBUG_PORT`), allowing debugger clients to inspect registers, memory, set breakpoints, and step through SBPF execution
- Extract GDB RSP client helpers into a public `debugger` module for reuse by external tooling
- Refactor `elf_accounts_to_sha256` to deduplicate program IDs with HashSet and only persist ELF mappings when the debugger port is set
- Add CPI-aware debugger test

**Note**

Creating a new PR was easier than to reworking https://github.com/anza-xyz/mollusk/pull/200 which I can close once this PR is settled. In regards to the initially suggested SBF filtering, I think it's better to come in with a follow-up PR.