### PR TITLE
ci: harden the publish pipeline with ownership + dry-run gates

### DIFF
--- a/.github/actions/publish-setup/action.yml
+++ b/.github/actions/publish-setup/action.yml
@@ -1,0 +1,48 @@
+name: Publish setup
+description: Shared setup for publish jobs — cargo cache, protoc, and the Solana toolchain.
+
+inputs:
+  nightly:
+    description: Install the nightly toolchain with rustfmt and clippy.
+    default: "false"
+  cargo-hack:
+    description: Install cargo-hack.
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: cargo-build-sbf-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          cargo-build-sbf-
+    - name: Install protoc
+      shell: bash
+      run: sudo apt-get install -y protobuf-compiler
+    - name: Get nightly toolchain version
+      if: inputs.nightly == 'true'
+      id: nightly
+      shell: bash
+      run: echo "version=$(make nightly-version)" >> "$GITHUB_OUTPUT"
+    - uses: dtolnay/rust-toolchain@master
+      if: inputs.nightly == 'true'
+      with:
+        toolchain: ${{ steps.nightly.outputs.version }}
+        components: rustfmt, clippy
+    - name: Get Solana version
+      id: solana
+      shell: bash
+      run: echo "version=$(make solana-version)" >> "$GITHUB_OUTPUT"
+    - uses: metaplex-foundation/actions/install-solana@v1
+      with:
+        cache: true
+        version: ${{ steps.solana.outputs.version }}
+    - name: Install cargo-hack
+      if: inputs.cargo-hack == 'true'
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-hack

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,71 +12,58 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/agave-4.0'
     permissions:
       contents: read
-
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/cache@v5
+      - uses: ./.github/actions/publish-setup
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-build-sbf-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-build-sbf-
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-      - name: Get nightly toolchain version
-        id: nightly
-        run: echo "version=$(make nightly-version)" >> $GITHUB_OUTPUT
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ steps.nightly.outputs.version }}
-          components: rustfmt, clippy
-      - name: Get Solana version
-        id: solana
-        run: echo "version=$(make solana-version)" >> $GITHUB_OUTPUT
-      - uses: metaplex-foundation/actions/install-solana@v1
-        with:
-          cache: true
-          version: ${{ steps.solana.outputs.version }}
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-hack
+          nightly: "true"
+          cargo-hack: "true"
       - name: Prepublish
         shell: bash
         run: make prepublish
+
+  verify_crate_owners:
+    name: Verify crate owners
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/agave-4.0'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify crate owners
+        shell: bash
+        run: make verify-crate-owners
+
+  publish_dry_run:
+    name: Publish dry-run
+    runs-on: ubuntu-latest
+    needs: [pre_publish, verify_crate_owners]
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/agave-4.0'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/publish-setup
+      - name: Dry-run publish
+        shell: bash
+        env:
+          ARGS: "--locked"
+        run: make publish DRY_RUN=--dry-run
 
   publish:
     name: Publish
     runs-on: ubuntu-latest
     environment: prod
-    needs: pre_publish
+    needs: [pre_publish, publish_dry_run, verify_crate_owners]
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/agave-4.0'
     permissions:
       id-token: write
       attestations: write
       artifact-metadata: write
       contents: read
-
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-build-sbf-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-build-sbf-
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-      - name: Get Solana version
-        id: solana
-        run: echo "version=$(make solana-version)" >> $GITHUB_OUTPUT
-      - uses: metaplex-foundation/actions/install-solana@v1
-        with:
-          cache: true
-          version: ${{ steps.solana.outputs.version }}
+      - uses: ./.github/actions/publish-setup
       - name: Package
         shell: bash
         env:
@@ -91,6 +78,6 @@ jobs:
       - name: Publish
         shell: bash
         env:
-          TOKEN: ${{ steps.auth.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
           ARGS: "--locked"
         run: make publish

--- a/Makefile
+++ b/Makefile
@@ -21,22 +21,9 @@ SOLANA_VERSION := 4.0.0
 	audit \
 	check-features \
 	prepublish \
+	verify-crate-owners \
 	package \
 	publish
-
-# Crates to publish, in dependency order
-PUBLISH_CRATES := \
-	mollusk-svm-error \
-	mollusk-svm-fuzz-fs \
-	mollusk-svm-fuzz-fixture \
-	mollusk-svm-fuzz-fixture-firedancer \
-	mollusk-svm-result \
-	mollusk-svm \
-	mollusk-svm-bencher \
-	mollusk-svm-programs-memo \
-	mollusk-svm-programs-token-2022 \
-	mollusk-svm-programs-token \
-	mollusk-svm-cli
 
 # Advisories to ignore for audit.
 # - RUSTSEC-2022-0093: ed25519-dalek: Double Public Key Signing Function Oracle Attack
@@ -120,18 +107,14 @@ prepublish:
 	@$(MAKE) check-features
 	@$(MAKE) test
 
-# Package crates into target/package/*.crate (so attestation can sign them
-# before publish). Uses multi-package mode to resolve workspace inter-deps.
-package:
-	@cargo package $(addprefix -p ,$(PUBLISH_CRATES)) $(ARGS)
+verify-crate-owners:
+	@./scripts/verify-crate-owners.sh
 
-# Publish crates in dependency order
+# Package all workspace crates into target/package/*.crate (so attestation can
+# sign them before publish).
+package:
+	@cargo package --workspace $(ARGS)
+
+DRY_RUN ?=
 publish:
-	@set -e && set -u && set -o pipefail && \
-	for crate in $(PUBLISH_CRATES); do \
-		echo "Publishing $$crate..." && \
-		cargo publish -p $$crate --token $$TOKEN $(ARGS) && \
-		echo "$$crate published successfully!" && \
-		sleep 5; \
-	done && \
-	echo "All crates published successfully!"
+	@cargo publish --workspace $(DRY_RUN) $(ARGS)

--- a/scripts/verify-crate-owners.sh
+++ b/scripts/verify-crate-owners.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Verify that every publishable crate in the workspace already exists on
+# crates.io and is owned by the trusted Anza team.
+#
+# Adapted from ci/check-crates.sh in anza-xyz/agave.
+
+set -euo pipefail
+
+readonly VERIFIED_OWNER="${VERIFIED_OWNER:-anza-team}"
+readonly USER_AGENT="Anza (https://github.com/anza-xyz/mollusk)"
+
+crate_owners() {
+	local crate="$1"
+	curl -fsS -A "$USER_AGENT" "https://crates.io/api/v1/crates/${crate}/owners" \
+		| jq -r '.users[].login'
+}
+
+main() {
+	local crates
+	mapfile -t crates < <(
+		cargo metadata --no-deps --format-version 1 \
+			| jq -r '.packages[] | select(.publish == null or (.publish | length > 0)) | .name'
+	)
+
+	if [[ ${#crates[@]} -eq 0 ]]; then
+		echo "error: no publishable crates found in workspace" >&2
+		exit 1
+	fi
+
+	local crate owners failed=()
+	for crate in "${crates[@]}"; do
+		if ! owners="$(crate_owners "$crate")"; then
+			echo "  ✗ ${crate}: not found on crates.io (needs a devops bootstrap)" >&2
+			failed+=("$crate")
+		elif grep -qxF "$VERIFIED_OWNER" <<<"$owners"; then
+			echo "  ✓ ${crate}"
+		else
+			echo "  ✗ ${crate}: not owned by ${VERIFIED_OWNER} (owners: ${owners//$'\n'/, })" >&2
+			failed+=("$crate")
+		fi
+	done
+
+	if [[ ${#failed[@]} -gt 0 ]]; then
+		echo "error: ${#failed[@]} crate(s) failed ownership verification: ${failed[*]}" >&2
+		exit 1
+	fi
+
+	echo "verified ${#crates[@]} publishable crates owned by ${VERIFIED_OWNER}"
+}
+
+main "$@"

--- a/scripts/verify-crate-owners.sh
+++ b/scripts/verify-crate-owners.sh
@@ -7,6 +7,10 @@
 
 set -euo pipefail
 
+# Run from the workspace root so `cargo metadata` resolves this workspace
+# regardless of the caller's working directory.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
 readonly VERIFIED_OWNER="${VERIFIED_OWNER:-anza-team}"
 readonly USER_AGENT="Anza (https://github.com/anza-xyz/mollusk)"
 


### PR DESCRIPTION
Add two pre-flight gates to the publish workflow so a release can't fail partway and poison crates.io (as happened for token-2022 in 0.13.2):

- verify_crate_owners: a tokenless check (scripts/verify-crate-owners.sh) that every publishable crate already exists on crates.io and is owned by the trusted anza-team. Runs in parallel with prepublish.
- publish_dry_run: a full `cargo publish --workspace --dry-run` that builds and packages every crate before any real upload.

Both gate the real publish job.

Also modernize the publish recipes and de-duplicate CI setup:

- publish/package use `cargo {publish,package} --workspace`, dropping the hand-maintained PUBLISH_CRATES list and the per-crate loop + sleeps; cargo orders the crates and waits for index propagation itself.
- the real publish reads the token from CARGO_REGISTRY_TOKEN.
- a publish-setup composite action holds the shared cache/protoc/solana setup reused across the publish jobs.