### PR TITLE
ci: bump nightly toolchain to nightly-2026-04-11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /usr/bin/env bash
-NIGHTLY_TOOLCHAIN := nightly-2025-10-07
+NIGHTLY_TOOLCHAIN := nightly-2026-04-11
 SOLANA_VERSION := 4.0.0
 
 

--- a/harness/tests/fd_test_vectors.rs
+++ b/harness/tests/fd_test_vectors.rs
@@ -143,8 +143,8 @@ fn compare_accounts(
     let mut b_sorted = b.to_vec();
 
     // Sort by Pubkey
-    a_sorted.sort_by(|(pubkey_a, _, _), (pubkey_b, _, _)| pubkey_a.cmp(pubkey_b));
-    b_sorted.sort_by(|(pubkey_a, _, _), (pubkey_b, _, _)| pubkey_a.cmp(pubkey_b));
+    a_sorted.sort_by_key(|(pubkey_a, _, _)| *pubkey_a);
+    b_sorted.sort_by_key(|(pubkey_a, _, _)| *pubkey_a);
 
     // Compare sorted lists
     a_sorted == b_sorted
@@ -159,8 +159,8 @@ fn compare_instruction_accounts(a: &[InstructionAccount], b: &[InstructionAccoun
     let mut b_sorted = b.to_vec();
 
     // Sort by index_in_transaction
-    a_sorted.sort_by(|ia_a, ia_b| ia_a.index_in_transaction.cmp(&ia_b.index_in_transaction));
-    b_sorted.sort_by(|ia_a, ia_b| ia_a.index_in_transaction.cmp(&ia_b.index_in_transaction));
+    a_sorted.sort_by_key(|ia_a| ia_a.index_in_transaction);
+    b_sorted.sort_by_key(|ia_a| ia_a.index_in_transaction);
 
     // Compare sorted lists; InstructionAccount no longer implements PartialEq
     a_sorted


### PR DESCRIPTION
The pinned nightly (nightly-2025-10-07) is stale. Bump it and address the new clippy lint it surfaces (unnecessary_sort_by -> sort_by_key).