### PR TITLE
deps: Agave with ABIv2 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,8 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402f8462d64e03c9b09a96b1898f7dbc8b9c5d6e9534fb777905df599ad5d787"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "ahash",
  "solana-epoch-schedule",
@@ -55,9 +54,8 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a97e478437ac3d1cc1446600afb972e446736b301b02f0c1ba31d81bb0c91b6"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -236,7 +234,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -255,7 +253,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version",
@@ -276,7 +274,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "zeroize",
@@ -308,7 +306,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -321,7 +319,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -365,7 +363,7 @@ dependencies = [
  "ark-serialize-derive 0.4.2",
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -378,7 +376,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -615,9 +613,9 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -981,36 +979,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1028,22 +1002,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -1617,6 +1580,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,7 +1839,7 @@ checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
- "num-bigint 0.4.6",
+ "num-bigint",
  "thiserror 1.0.69",
 ]
 
@@ -1879,7 +1851,7 @@ checksum = "47a1ccadd0bb5a32c196da536fd72c59183de24a055f6bf0513bf845fefab862"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "thiserror 1.0.69",
 ]
 
@@ -1900,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "managed"
@@ -1941,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm"
-version = "0.14.0"
+version = "0.14.0-agave-4.2.0-beta.0"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -1972,7 +1944,7 @@ dependencies = [
  "solana-hash",
  "solana-instruction",
  "solana-instruction-error",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 3.0.0",
  "solana-loader-v3-interface",
  "solana-logger",
  "solana-message",
@@ -1991,7 +1963,6 @@ dependencies = [
  "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-timings",
- "solana-svm-transaction",
  "solana-syscalls",
  "solana-system-interface",
  "solana-system-program",
@@ -2006,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-bencher"
-version = "0.14.0"
+version = "0.14.0-agave-4.2.0-beta.0"
 dependencies = [
  "chrono",
  "mollusk-svm",
@@ -2020,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-cli"
-version = "0.14.0"
+version = "0.14.0-agave-4.2.0-beta.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2039,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-error"
-version = "0.14.0"
+version = "0.14.0-agave-4.2.0-beta.0"
 dependencies = [
  "solana-pubkey 4.2.0",
  "thiserror 2.0.19",
@@ -2047,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-fuzz-fixture"
-version = "0.14.0"
+version = "0.14.0-agave-4.2.0-beta.0"
 dependencies = [
  "agave-feature-set",
  "mollusk-svm-fuzz-fs",
@@ -2072,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-fuzz-fixture-firedancer"
-version = "0.14.0"
+version = "0.14.0-agave-4.2.0-beta.0"
 dependencies = [
  "agave-feature-set",
  "mollusk-svm-fuzz-fs",
@@ -2088,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-fuzz-fs"
-version = "0.14.0"
+version = "0.14.0-agave-4.2.0-beta.0"
 dependencies = [
  "bs58",
  "prost",
@@ -2099,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-programs-memo"
-version = "0.14.0"
+version = "0.14.0-agave-4.2.0-beta.0"
 dependencies = [
  "mollusk-svm",
  "solana-account",
@@ -2108,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-programs-token"
-version = "0.14.0"
+version = "0.14.0-agave-4.2.0-beta.0"
 dependencies = [
  "mollusk-svm",
  "mollusk-svm-programs-token-2022",
@@ -2122,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-programs-token-2022"
-version = "0.14.0"
+version = "0.14.0-agave-4.2.0-beta.0"
 dependencies = [
  "mollusk-svm",
  "solana-account",
@@ -2138,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-result"
-version = "0.14.0"
+version = "0.14.0-agave-4.2.0-beta.0"
 dependencies = [
  "mollusk-svm-fuzz-fixture",
  "serde",
@@ -2159,47 +2130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "num"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
-dependencies = [
- "num-bigint 0.2.6",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
-dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -2230,29 +2166,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-dependencies = [
- "autocfg",
- "num-bigint 0.2.6",
- "num-integer",
  "num-traits",
 ]
 
@@ -2437,15 +2350,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "percentage"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd23b938276f14057220b707937bcb42fa76dda7560e57a2da30cb52d557937"
-dependencies = [
- "num",
-]
 
 [[package]]
 name = "petgraph"
@@ -2994,7 +2898,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3163,9 +3067,8 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e3429eb6f1aa8b330307d77b14d95d347a55641b6c5b795b2ca98875faa333"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "base64",
  "bs58",
@@ -3211,7 +3114,7 @@ dependencies = [
  "serde_derive",
  "sha2-const-stable",
  "solana-atomic-u64",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-nullable",
  "solana-program-error",
  "solana-sanitize",
@@ -3230,13 +3133,12 @@ dependencies = [
 
 [[package]]
 name = "solana-big-mod-exp"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
+checksum = "f05789c4afc39164132db9dcc117218d412ca1f1271d2c629fc6f554c19e5a44"
 dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "solana-define-syscall 3.0.0",
+ "num-bigint",
+ "solana-define-syscall 5.2.0",
 ]
 
 [[package]]
@@ -3308,7 +3210,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "bytemuck",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "thiserror 2.0.19",
 ]
 
@@ -3323,9 +3225,8 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "405953767b67426780c616218b911d095e00fbf97bdfe7e9d0b83002ec4b0731"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -3370,9 +3271,8 @@ checksum = "1517aa49dcfa9cb793ef90e7aac81346d62ca4a546bb1a754030a033e3972e1c"
 
 [[package]]
 name = "solana-compute-budget"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5029b1e141344bba1261d5c28de8067cb89927bb06fbbfa71df6ef84d25eaf1b"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -3380,9 +3280,8 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c05c42c6d7a20d221ba188d0ab6914081910e8ff4b35c02e6536b94104f575c"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -3424,7 +3323,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "subtle",
  "thiserror 2.0.19",
 ]
@@ -3443,9 +3342,9 @@ checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
 
 [[package]]
 name = "solana-define-syscall"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
+checksum = "bf8209ece2bd9f1450e672858ffc0e5c8c786ff6916d2a862b126dd0128f380f"
 
 [[package]]
 name = "solana-derivation-path"
@@ -3514,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "solana-fee-structure"
-version = "3.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2abdb1223eea8ec64136f39cb1ffcf257e00f915c957c35c0dd9e3f4e700b0"
+checksum = "3591f4827715ebb49c290b829f707ec1747a152973436f27699897f752a31cd6"
 
 [[package]]
 name = "solana-get-sysvar"
@@ -3525,15 +3424,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef3bc859fc036ed490146793557386cbfae614ebba4adc704c37d94350824ed4"
 dependencies = [
  "solana-address 2.6.1",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-program-error",
 ]
 
 [[package]]
 name = "solana-hash"
-version = "4.4.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe51db00ac3aa9f950d1e6201a126acfa26e6d81bc4a183ba64ec02effcad883"
+checksum = "6f4c847893a2ea50b4ae3ca723b124e07cd0544fecea3598f785168f9b78333f"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -3558,8 +3457,7 @@ checksum = "37ebb0ffd19263051bc3f683fcc086134b8ff23af894dcb63f7563c7137b42f1"
 dependencies = [
  "bincode",
  "serde",
- "serde_derive",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
  "wincode",
@@ -3567,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction-error"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b188842592fdf6cb96f55263ae1bf11713ab5114401d1d5a881ed7cc41bef6"
+checksum = "3b7d34343838343a3755b7dfb1e438d94c6db2263b519cfe3c2257af932b6e93"
 dependencies = [
  "num-traits",
  "serde",
@@ -3589,6 +3487,23 @@ dependencies = [
  "solana-instruction-error",
  "solana-program-error",
  "solana-pubkey 3.0.0",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-serialize-utils",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-instructions-sysvar"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e38363a181313d607f7a118df2b401bb27b477a0104b09283cbf504f5f0f00cc"
+dependencies = [
+ "bitflags 2.11.1",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-program-error",
  "solana-sanitize",
  "solana-sdk-ids",
  "solana-serialize-utils",
@@ -3665,9 +3580,9 @@ dependencies = [
 
 [[package]]
 name = "solana-message"
-version = "4.2.3"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94164f9740d40f41568f6f48140a0866251a79a7bce013eb4ffefe12d0e38cc"
+checksum = "cfe614646c48c59fff4d47ebd893c13d74c85a32573a45dadde430b13f576d64"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3687,7 +3602,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
 dependencies = [
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
 ]
 
 [[package]]
@@ -3698,9 +3613,9 @@ checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
 
 [[package]]
 name = "solana-nonce"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95dbc9f2e33b6c10e231df15cb2a3bff9ea7eab6347f9e316fe75c97fd67bbb"
+checksum = "c4172d5b33a0a38fcdb2af8f84406570dd51567267da96c28ad0f31fc11621c0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3713,9 +3628,9 @@ dependencies = [
 
 [[package]]
 name = "solana-nonce-account"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda945f4ccb317791c26379ca8ec410c5938aa7a5eff211fe5fe0bb428c3a75f"
+checksum = "b81bf7e2aa8c443724051507c1007d0b6d9c34b70925d3232dc78f5ca485209e"
 dependencies = [
  "solana-account",
  "solana-hash",
@@ -3736,9 +3651,9 @@ dependencies = [
 
 [[package]]
 name = "solana-packet"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad62e1045c2347a0c0e219a6ceb0abfe904be622920996bfcac8d116fabe3c7"
+checksum = "43a2a582d7863548f047f49aa3745c076cfa9e1364baa080ef0c1210f0e4ebda"
 dependencies = [
  "bitflags 2.11.1",
  "solana-pubkey 4.2.0",
@@ -3814,16 +3729,15 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0adc57a87fb47da184a3d626560cb0001943201142dc1639ac4a46a17e1b68d"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "base64",
  "bincode",
  "cfg-if",
  "itertools 0.14.0",
  "log",
- "percentage",
+ "qualifier_attr",
  "rand 0.9.4",
  "serde",
  "solana-account",
@@ -3836,6 +3750,7 @@ dependencies = [
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-loader-v3-interface",
+ "solana-message",
  "solana-program-entrypoint",
  "solana-pubkey 4.2.0",
  "solana-rent",
@@ -3843,7 +3758,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-slot-hashes",
  "solana-stable-layout",
- "solana-stake-interface",
+ "solana-stake-history",
  "solana-svm-callback",
  "solana-svm-feature-set",
  "solana-svm-log-collector",
@@ -3856,6 +3771,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-transaction-context",
  "thiserror 2.0.19",
+ "wincode",
 ]
 
 [[package]]
@@ -3909,9 +3825,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f84c593fa3d4131045b606dec5acf9d8eac73791bc786ca9911057aec8f43ec"
+checksum = "8e0f2767643b3609343f18b43c222a36aaae274940b86bee0553f898f83007a3"
 dependencies = [
  "byteorder",
  "combine",
@@ -3965,12 +3881,12 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256k1-recover"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5f18893d62e6c73117dcba48f8f5e3266d90e5ec3d0a0a90f9785adac36c1"
+checksum = "e3a1ad3ed7846631c88c71c5d2f21a2ecb6b61da333d9be173b6b061b35609ae"
 dependencies = [
  "k256",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "thiserror 2.0.19",
 ]
 
@@ -4044,7 +3960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11e10e103ab5bd52af341e7bc2f4123a2f4e66bb7ba4e6ca40f1e00cd6314e02"
 dependencies = [
  "sha2 0.10.9",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-hash-512",
 ]
 
@@ -4075,11 +3991,11 @@ dependencies = [
 
 [[package]]
 name = "solana-signer"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bfea97951fee8bae0d6038f39a5efcb6230ecdfe33425ac75196d1a1e3e3235"
+checksum = "520bd6021163ee517f4bdc7ae03ded904f97e11320001ba0b3355f45eb14f558"
 dependencies = [
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.2.0",
  "solana-signature",
  "solana-transaction-error",
 ]
@@ -4096,6 +4012,7 @@ dependencies = [
  "solana-hash",
  "solana-sdk-ids",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -4137,29 +4054,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-stake-interface"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
-dependencies = [
- "num-traits",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-cpi",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey 4.2.0",
- "solana-system-interface",
- "solana-sysvar",
- "solana-sysvar-id",
-]
-
-[[package]]
 name = "solana-svm-callback"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3170a3cfc032f3efca975154dee904ecefea5ae11fbd50787c062886196d32c1"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -4169,30 +4066,26 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3d427bb7cd5182365e7e89d73fcfcb54565d15445ad2d228921811c3836099"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdf3074910afe016266bf73606724543b6829b5656221c8060ebcfcc844b39a"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ecaaadf4ddaabdba865c7f9aade0c51ac7c393c786f8b4e9590127f5ee9d62"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 
 [[package]]
 name = "solana-svm-timings"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b179027c8bf618df4a7f02f937ddef54770f8f5584195c94a03437ee6dc7c7f3"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -4201,9 +4094,9 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "4.1.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa27dd1eb7ce4d339cf9dfc1dfb70866488e4e1436fb05728aea7af0185191a"
+checksum = "736d2cec944c6f8f298a7bd8ada5eb318cca9ab859281b1300842fa0e9a25afa"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -4215,18 +4108,16 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0ca52c449480ab3a1ef614ae10576d6ccc33730a0f4d8b4a69f38e8decb622"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "rand 0.9.4",
 ]
 
 [[package]]
 name = "solana-syscalls"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d855514df361d211bd254929ab816321f3bd136f3b985605c68ba68a1b1d729"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "bincode",
  "libsecp256k1",
@@ -4240,6 +4131,7 @@ dependencies = [
  "solana-clock",
  "solana-cpi",
  "solana-curve25519 4.0.1",
+ "solana-define-syscall 5.2.0",
  "solana-hash",
  "solana-hash-512",
  "solana-instruction",
@@ -4254,7 +4146,7 @@ dependencies = [
  "solana-sha256-hasher",
  "solana-sha512-hasher",
  "solana-stable-layout",
- "solana-stake-interface",
+ "solana-stake-history",
  "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-type-overrides",
@@ -4262,6 +4154,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-transaction-context",
  "thiserror 2.0.19",
+ "wincode",
 ]
 
 [[package]]
@@ -4282,9 +4175,8 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84eaae98e1576c1b490760d102ca15cb0cfc7ed2b52012dc0d06698a2529e093"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "bincode",
  "log",
@@ -4317,7 +4209,7 @@ dependencies = [
  "serde_derive",
  "solana-account-info",
  "solana-clock",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
@@ -4350,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction"
-version = "4.1.2"
+version = "4.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45eb9e481a70f582be316d0bf2f8f8704079664e636a4e5d0c0d077f1c9de8f3"
+checksum = "6aa9b0f8543b99e1cb7db16a7c1a392139d82db57a90d262fb0a394807337bec"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4372,16 +4264,15 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168e409c531b6e5b4a4bcf4a0286795acb80e6c6330c21fe6ad5d7e6918a7245"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "bincode",
  "qualifier_attr",
  "serde",
  "solana-account",
  "solana-instruction",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 4.0.0",
  "solana-pubkey 4.2.0",
  "solana-rent",
  "solana-sbpf",
@@ -4390,9 +4281,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757a648388ab1e7350a806ffceb31ce656dc5b5fe607b9f8209aa56f63040179"
+checksum = "a949797bc1ac31836d0070e791083028a8c2e0d493fa4cf51c0bed7a04c65c22"
 dependencies = [
  "serde",
  "serde_derive",
@@ -4402,9 +4293,8 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6252e3d627009fcab17480ec4208143f9bc66fcf7c673a44c933741241edb6aa"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "base64",
  "bincode",
@@ -4426,9 +4316,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "6.0.2"
+version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61843d7be827cac5e025c3a16c1101a34fcdd8cf593f6a82eafdd253bd55a26b"
+checksum = "13a7a204b455a53fe8c9a26a6885391a5896835e06694dbe0cf37c580f82f128"
 dependencies = [
  "bincode",
  "cfg_eval",
@@ -4452,9 +4342,8 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8c997fe9d53a3906013635aab248c04896c6aac11b5f2e09a4f836e9688b329"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -4505,47 +4394,46 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c61b68701d57e260b4f0bd7f2872709d907689ff4d750673a7b55e67de0372"
+version = "4.3.0-alpha.2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "bytemuck",
  "solana-instruction",
  "solana-program-runtime",
  "solana-sdk-ids",
  "solana-svm-log-collector",
+ "solana-zk-elgamal-proof-interface",
  "solana-zk-sdk",
 ]
 
 [[package]]
 name = "solana-zk-sdk"
-version = "5.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09670ff59f60e6ddc2209c2e4353992a9b9f01d4e244f3e9d67bd5146e33d388"
+checksum = "96cd8535d2f40d43a1d47af2849e1c86706a597a2ad84207441f51a50f09d8fd"
 dependencies = [
  "aes-gcm-siv",
  "base64",
  "bincode",
  "bytemuck",
- "bytemuck_derive",
  "curve25519-dalek 4.1.3",
+ "hkdf",
  "itertools 0.14.0",
  "merlin",
- "num-derive",
- "num-traits",
  "rand 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2 0.10.9",
  "sha3",
  "solana-address 2.6.1",
  "solana-derivation-path",
- "solana-instruction",
- "solana-sdk-ids",
  "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk-pod",
  "subtle",
  "thiserror 2.0.19",
  "zeroize",
@@ -4661,7 +4549,7 @@ dependencies = [
  "solana-address 2.6.1",
  "solana-curve25519 3.1.14",
  "solana-instruction",
- "solana-instructions-sysvar",
+ "solana-instructions-sysvar 3.0.0",
  "solana-msg",
  "solana-program-error",
  "solana-sdk-ids",
@@ -5131,9 +5019,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincode"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37095eb18dd6254c66217edc61a29d83d51f8818de8a2ffe88e4584ad73fb5f9"
+checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
 dependencies = [
  "pastey",
  "proc-macro2",
@@ -5144,11 +5032,11 @@ dependencies = [
 
 [[package]]
 name = "wincode-derive"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262d55d1261f31e2cfe49cc6385a421d14d99faa0526bbe3cc1bda0d3005c62"
+checksum = "15ab90b719560d0fda79c74550ad1c948d17b118765942838055ebaf34d67071"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ repository = "https://github.com/anza-xyz/mollusk"
 readme = "README.md"
 license-file = "LICENSE"
 edition = "2021"
-version = "0.14.0"
+version = "0.14.0-abiv2"
 
 [workspace.dependencies]
-agave-feature-set = "4.1.1"
-agave-precompiles = "4.1.1"
+agave-feature-set = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+agave-precompiles = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
 bincode = "1.3.3"
 bs58 = "0.5.1"
 chrono = "0.4.44"
@@ -30,17 +30,17 @@ criterion = "0.8.2"
 hex = "0.4.3"
 ed25519-dalek = "=2.1.1"
 libsecp256k1 = "0.7.2"
-mollusk-svm = { path = "harness", version = "0.14.0" }
-mollusk-svm-bencher = { path = "bencher", version = "0.14.0" }
-mollusk-svm-cli = { path = "cli", version = "0.14.0" }
-mollusk-svm-error = { path = "error", version = "0.14.0" }
-mollusk-svm-fuzz-fixture = { path = "fuzz/fixture", version = "0.14.0" }
-mollusk-svm-fuzz-fixture-firedancer = { path = "fuzz/fixture-fd", version = "0.14.0" }
-mollusk-svm-fuzz-fs = { path = "fuzz/fs", version = "0.14.0" }
-mollusk-svm-programs-memo = { path = "programs/memo", version = "0.14.0" }
-mollusk-svm-result = { path = "result", version = "0.14.0" }
-mollusk-svm-programs-token = { path = "programs/token", version = "0.14.0" }
-mollusk-svm-programs-token-2022 = { path = "programs/token-2022", version = "0.14.0" }
+mollusk-svm = { path = "harness", version = "0.14.0-agave-4.2.0-beta.0" }
+mollusk-svm-bencher = { path = "bencher", version = "0.14.0-agave-4.2.0-beta.0" }
+mollusk-svm-cli = { path = "cli", version = "0.14.0-agave-4.2.0-beta.0" }
+mollusk-svm-error = { path = "error", version = "0.14.0-agave-4.2.0-beta.0" }
+mollusk-svm-fuzz-fixture = { path = "fuzz/fixture", version = "0.14.0-agave-4.2.0-beta.0" }
+mollusk-svm-fuzz-fixture-firedancer = { path = "fuzz/fixture-fd", version = "0.14.0-agave-4.2.0-beta.0" }
+mollusk-svm-fuzz-fs = { path = "fuzz/fs", version = "0.14.0-agave-4.2.0-beta.0" }
+mollusk-svm-programs-memo = { path = "programs/memo", version = "0.14.0-agave-4.2.0-beta.0" }
+mollusk-svm-result = { path = "result", version = "0.14.0-agave-4.2.0-beta.0" }
+mollusk-svm-programs-token = { path = "programs/token", version = "0.14.0-agave-4.2.0-beta.0" }
+mollusk-svm-programs-token-2022 = { path = "programs/token-2022", version = "0.14.0-agave-4.2.0-beta.0" }
 num-format = "0.4.4"
 openssl = "0.10.78"
 prost = "0.14"
@@ -55,10 +55,10 @@ serial_test = "2.0"
 sha2 = "0.10.9"
 solana-account = "4.3.0"
 solana-account-info = "3.1.0"
-solana-bpf-loader-program = "4.1.1"
+solana-bpf-loader-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
 solana-clock = "3.0.1"
-solana-compute-budget = "4.1.1"
-solana-compute-budget-program = "4.1.1"
+solana-compute-budget = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-compute-budget-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
 solana-cpi = "3.1.0"
 solana-ed25519-program = "3.0.0"
 solana-epoch-rewards = "3.0.0"
@@ -71,7 +71,7 @@ solana-instructions-sysvar = "3.0.0"
 solana-keccak-hasher = { version = "3.1.0", features = ["sha3"] }
 solana-loader-v3-interface = "7.0.0"
 solana-logger = "3.0.0"
-solana-message = "4.2.0"
+solana-message = "4.2.4"
 solana-msg = "3.0.0"
 solana-native-token = "3.0.0"
 solana-precompile-error = "3.0.0"
@@ -79,7 +79,7 @@ solana-program-entrypoint = "3.1.1"
 solana-program-error = "3.0.0"
 solana-program-option = "3.1.0"
 solana-program-pack = "3.1.0"
-solana-program-runtime = "4.1.1"
+solana-program-runtime = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
 solana-pubkey = "4.1.0"
 solana-rent = "4.2.0"
 solana-sdk-ids = "3.1.0"
@@ -87,21 +87,20 @@ solana-secp256k1-program = "3.0.1"
 solana-secp256r1-program = "3.0.0"
 solana-slot-hashes = "3.0.1"
 solana-stake-history = "1.0.0"
-solana-svm-callback = "4.1.1"
-solana-svm-feature-set = "4.1.1"
-solana-svm-log-collector = "4.1.1"
-solana-svm-timings = "4.1.1"
-solana-svm-transaction = "4.1.1"
-solana-syscalls = "4.1.1"
+solana-svm-callback = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-svm-feature-set = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-svm-log-collector = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-svm-timings = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-syscalls = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
 solana-system-interface = "3.0"
-solana-system-program = "4.1.1"
+solana-system-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
 solana-sysvar = "4.0.0"
 solana-sysvar-id = "3.1.0"
-solana-transaction-context = "4.1.1"
+solana-transaction-context = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
 solana-transaction-error = "3.0.0"
-solana-transaction-status-client-types = "4.1.1"
-solana-vote-program = "4.1.1"
-solana-zk-elgamal-proof-program = "4.1.1"
+solana-transaction-status-client-types = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-vote-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-zk-elgamal-proof-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
 spl-associated-token-account-interface = "2.0.0"
 spl-token-2022-interface = "3.0.1"
 spl-token-group-interface = "0.7.2"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /usr/bin/env bash
 NIGHTLY_TOOLCHAIN := nightly-2026-04-11
-SOLANA_VERSION := 4.0.0
+SOLANA_VERSION := 4.3.0-alpha.0
 
 
 .PHONY: \

--- a/fuzz/fixture/proto/compute_budget.proto
+++ b/fuzz/fixture/proto/compute_budget.proto
@@ -62,4 +62,8 @@ message ComputeBudget {
     uint64 bls12_381_g2_validate_cost = 58;
     uint64 bls12_381_one_pair_cost = 59;
     uint64 bls12_381_additional_pair_cost = 60;
+    uint64 set_buffer_length_base_cost = 61;
+    uint64 abi_v2_assign_owner = 62;
+    uint64 sol_transfer_lamports_cost = 63;
+    uint64 abi_v2_cpi_base = 64;
 }

--- a/fuzz/fixture/src/compute_budget.rs
+++ b/fuzz/fixture/src/compute_budget.rs
@@ -66,6 +66,10 @@ impl From<ProtoComputeBudget> for ComputeBudget {
             bls12_381_g2_validate_cost,
             bls12_381_one_pair_cost,
             bls12_381_additional_pair_cost,
+            set_buffer_length_base_cost,
+            abi_v2_assign_owner,
+            sol_transfer_lamports_cost,
+            abi_v2_cpi_base,
         } = value;
 
         Self {
@@ -127,6 +131,10 @@ impl From<ProtoComputeBudget> for ComputeBudget {
             bls12_381_g2_validate_cost,
             bls12_381_one_pair_cost,
             bls12_381_additional_pair_cost,
+            set_buffer_length_base_cost,
+            abi_v2_assign_owner,
+            sol_transfer_lamports_cost,
+            abi_v2_cpi_base,
         }
     }
 }
@@ -192,6 +200,10 @@ impl From<ComputeBudget> for ProtoComputeBudget {
             bls12_381_g2_validate_cost,
             bls12_381_one_pair_cost,
             bls12_381_additional_pair_cost,
+            set_buffer_length_base_cost,
+            abi_v2_assign_owner,
+            sol_transfer_lamports_cost,
+            abi_v2_cpi_base,
         } = value;
 
         Self {
@@ -253,6 +265,10 @@ impl From<ComputeBudget> for ProtoComputeBudget {
             bls12_381_g2_validate_cost,
             bls12_381_one_pair_cost,
             bls12_381_additional_pair_cost,
+            set_buffer_length_base_cost,
+            abi_v2_assign_owner,
+            sol_transfer_lamports_cost,
+            abi_v2_cpi_base,
         }
     }
 }
@@ -351,16 +367,6 @@ pub(crate) fn hash_proto_compute_budget(hasher: &mut Hasher, compute_budget: &Pr
             .alt_bn128_pairing_one_pair_cost_other
             .to_le_bytes(),
     );
-    hasher.hash(
-        &compute_budget
-            .big_modular_exponentiation_base_cost
-            .to_le_bytes(),
-    );
-    hasher.hash(
-        &compute_budget
-            .big_modular_exponentiation_cost_divisor
-            .to_le_bytes(),
-    );
     hasher.hash(&compute_budget.poseidon_cost_coefficient_a.to_le_bytes());
     hasher.hash(&compute_budget.poseidon_cost_coefficient_c.to_le_bytes());
     hasher.hash(
@@ -384,4 +390,8 @@ pub(crate) fn hash_proto_compute_budget(hasher: &mut Hasher, compute_budget: &Pr
     hasher.hash(&compute_budget.bls12_381_g2_validate_cost.to_le_bytes());
     hasher.hash(&compute_budget.bls12_381_one_pair_cost.to_le_bytes());
     hasher.hash(&compute_budget.bls12_381_additional_pair_cost.to_le_bytes());
+    hasher.hash(&compute_budget.set_buffer_length_base_cost.to_le_bytes());
+    hasher.hash(&compute_budget.abi_v2_assign_owner.to_le_bytes());
+    hasher.hash(&compute_budget.sol_transfer_lamports_cost.to_le_bytes());
+    hasher.hash(&compute_budget.abi_v2_cpi_base.to_le_bytes());
 }

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -75,7 +75,7 @@ solana-logger = { workspace = true }
 solana-message = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-program-error = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["agave-unstable-api"] }
+solana-program-runtime = { workspace = true, features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
@@ -85,7 +85,6 @@ solana-svm-callback = { workspace = true, features = ["agave-unstable-api"] }
 solana-svm-feature-set = { workspace = true, features = ["agave-unstable-api"] }
 solana-svm-log-collector = { workspace = true, features = ["agave-unstable-api"] }
 solana-svm-timings = { workspace = true, features = ["agave-unstable-api"] }
-solana-svm-transaction = { workspace = true, features = ["agave-unstable-api"] }
 solana-syscalls = { workspace = true, features = ["agave-unstable-api"] }
 solana-system-program = { workspace = true, features = ["agave-unstable-api"] }
 solana-sysvar = { workspace = true }

--- a/harness/src/feature_set.rs
+++ b/harness/src/feature_set.rs
@@ -35,9 +35,6 @@ pub fn svm_feature_set_to_feature_set(svm: &SVMFeatureSet) -> FeatureSet {
         enable_big_mod_exp_syscall,
         enable_get_epoch_stake_syscall,
         enable_poseidon_syscall,
-        enable_sbpf_v1_deployment_and_execution,
-        enable_sbpf_v2_deployment_and_execution,
-        enable_sbpf_v3_deployment_and_execution,
         enable_sha512_syscall,
         get_sysvar_syscall_enabled,
         last_restart_slot_sysvar,
@@ -69,6 +66,7 @@ pub fn svm_feature_set_to_feature_set(svm: &SVMFeatureSet) -> FeatureSet {
         block_revenue_sharing,
         vote_account_initialize_v2,
         direct_account_pointers_in_program_input,
+        program_runtime_abiv2,
     }
     fs
 }

--- a/harness/src/program.rs
+++ b/harness/src/program.rs
@@ -88,7 +88,7 @@ impl ProgramCache {
         enable_register_tracing: bool,
     ) -> Self {
         let me = Self {
-            cache: Rc::new(RefCell::new(ProgramCacheForTxBatch::default())),
+            cache: Rc::new(RefCell::new(ProgramCacheForTxBatch::new(1))),
             entries_cache: Rc::new(RefCell::new(HashMap::new())),
             program_runtime_environment: create_program_runtime_environment(
                 feature_set,
@@ -175,9 +175,8 @@ impl ProgramCache {
                     loader_key,
                     environment,
                     0,
-                    0,
+                    1,
                     elf,
-                    elf.len(),
                     &mut LoadProgramMetrics::default(),
                 )
                 .unwrap(),
@@ -247,7 +246,6 @@ impl Builtin {
     fn program_cache_entry(&self) -> Arc<ProgramCacheEntry> {
         Arc::new(ProgramCacheEntry::new_builtin(
             0,
-            self.name.len(),
             self.register_fn,
         ))
     }

--- a/harness/tests/abiv2.rs
+++ b/harness/tests/abiv2.rs
@@ -1,0 +1,9 @@
+//! Tests for ABIv2 features.
+
+use mollusk_svm::Mollusk;
+
+#[test]
+fn test_program_runtime_abiv2_feature_is_active_by_default() {
+    let mollusk = Mollusk::default();
+    assert!(mollusk.feature_set.program_runtime_abiv2);
+}

--- a/harness/tests/common/mod.rs
+++ b/harness/tests/common/mod.rs
@@ -38,9 +38,6 @@ pub fn compare_svm_feature_sets(a: &SVMFeatureSet, b: &SVMFeatureSet) {
         enable_big_mod_exp_syscall,
         enable_get_epoch_stake_syscall,
         enable_poseidon_syscall,
-        enable_sbpf_v1_deployment_and_execution,
-        enable_sbpf_v2_deployment_and_execution,
-        enable_sbpf_v3_deployment_and_execution,
         enable_sha512_syscall,
         get_sysvar_syscall_enabled,
         last_restart_slot_sysvar,
@@ -72,5 +69,6 @@ pub fn compare_svm_feature_sets(a: &SVMFeatureSet, b: &SVMFeatureSet) {
         block_revenue_sharing,
         vote_account_initialize_v2,
         direct_account_pointers_in_program_input,
+        program_runtime_abiv2,
     }
 }

--- a/harness/tests/elf_loading.rs
+++ b/harness/tests/elf_loading.rs
@@ -1,9 +1,6 @@
 //! Tests for loading SBPF ELFs.
 
-use {
-    mollusk_svm::{program::ProgramCache, Mollusk},
-    solana_pubkey::Pubkey,
-};
+use {mollusk_svm::Mollusk, solana_pubkey::Pubkey};
 
 #[test]
 fn test_sbpf_v0_elf_loads() {
@@ -33,41 +30,10 @@ fn test_sbpf_v2_elf_loads() {
 }
 
 #[test]
-fn test_sbpf_v3_feature_is_active_by_default() {
-    let mollusk = Mollusk::default();
-    assert!(mollusk.feature_set.enable_sbpf_v3_deployment_and_execution);
-}
-
-#[test]
-fn test_sbpf_v3_elf_loads_with_feature_enabled() {
+fn test_sbpf_v3_elf_loads() {
     std::env::set_var("SBF_OUT_DIR", "../target/deploy");
 
     let program_id = Pubkey::new_unique();
     let mut mollusk = Mollusk::default();
     mollusk.add_program(&program_id, "test_program_cpi_target_v3");
-}
-
-#[test]
-#[should_panic(expected = "called `Result::unwrap()` on an `Err` value: UnsupportedSBPFVersion")]
-fn test_sbpf_v3_elf_fails_without_feature() {
-    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
-
-    let mut mollusk = Mollusk::default();
-    mollusk.feature_set.enable_sbpf_v3_deployment_and_execution = false;
-
-    // Rebuild the program cache with the updated feature set so that
-    // the runtime environment no longer includes V3 in
-    // `enabled_sbpf_versions`.
-    mollusk.program_cache = ProgramCache::new(&mollusk.feature_set, &mollusk.compute_budget, false);
-
-    let program_id = Pubkey::new_unique();
-    let elf = mollusk_svm::file::load_program_elf("test_program_cpi_target_v3");
-
-    // Loading a V3 ELF should fail because V3 is not in the
-    // enabled range.
-    mollusk.program_cache.add_program(
-        &program_id,
-        &solana_sdk_ids::bpf_loader_upgradeable::ID,
-        &elf,
-    );
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.96.0"


### PR DESCRIPTION
### Problem

Agave will support ABIv2 runtime in a future version and currently it is not possible to test ABIv2 programs in mollusk.

### Solution

Update the agave dependencies to use the current work-in-progress ABIv2 Agave [fork](https://github.com/anza-xyz/agave-runtime). This allows testing ABIv2 programs – see https://github.com/febo/abiv2.