### PR TITLE
harness!: Add payer account to `process_transaction_instructions`

### DIFF
--- a/harness/src/compile_accounts.rs
+++ b/harness/src/compile_accounts.rs
@@ -15,10 +15,28 @@ pub fn compile_accounts<'a>(
     accounts: impl Iterator<Item = &'a (Pubkey, Account)>,
     fallback_accounts: &HashMap<Pubkey, Account>,
 ) -> (SanitizedMessage, Vec<(Pubkey, AccountSharedData)>) {
-    let message = Message::new(instructions, None);
+    compile_accounts_with_payer(instructions, accounts, fallback_accounts, None)
+}
+
+pub fn compile_accounts_with_payer<'a>(
+    instructions: &[Instruction],
+    accounts: impl Iterator<Item = &'a (Pubkey, Account)>,
+    fallback_accounts: &HashMap<Pubkey, Account>,
+    payer: Option<&Pubkey>,
+) -> (SanitizedMessage, Vec<(Pubkey, AccountSharedData)>) {
+    let message = Message::new(instructions, payer);
     let sanitized_message = SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()));
 
-    let accounts: Vec<_> = accounts.collect();
+    let mut accounts: Vec<_> = accounts.collect();
+
+    let payer_account = payer
+        .filter(|payer| !accounts.iter().any(|(key, _)| key == *payer))
+        .map(|payer| (*payer, Account::default()));
+
+    if let Some(payer_account) = payer_account.as_ref() {
+        accounts.insert(0, payer_account);
+    }
+
     let transaction_accounts = build_transaction_accounts(
         &sanitized_message,
         &accounts,

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -1323,19 +1323,8 @@ impl Mollusk {
 
     /// Process multiple instructions using a single shared transaction context.
     ///
-    /// This is the same as
-    /// [`Self::process_transaction_instructions_with_payer`], but without a
-    /// payer. In this case, the payer is assumed to be the first account in the
-    /// `accounts` slice.
-    pub fn process_transaction_instructions(
-        &self,
-        instructions: &[Instruction],
-        accounts: &[(Pubkey, Account)],
-    ) -> TransactionResult {
-        self.process_transaction_instructions_with_payer(instructions, accounts, None)
-    }
-
-    /// Process multiple instructions using a single shared transaction context.
+    /// When a transaction fee `payer` is not provided, it is assumed to be the
+    /// first account in the `accounts` slice.
     ///
     /// This API is the closest Mollusk offers to a transaction. All
     /// instructions are processed in the same message using the same
@@ -1351,7 +1340,7 @@ impl Mollusk {
     /// * `program_result`: The result code of the last program's execution and
     ///   its index.
     /// * `resulting_accounts`: The resulting accounts after all instructions.
-    pub fn process_transaction_instructions_with_payer(
+    pub fn process_transaction_instructions(
         &self,
         instructions: &[Instruction],
         accounts: &[(Pubkey, Account)],
@@ -1539,7 +1528,7 @@ impl Mollusk {
         accounts: &[(Pubkey, Account)],
         checks: &[Check],
     ) -> TransactionResult {
-        let result = self.process_transaction_instructions(instructions, accounts);
+        let result = self.process_transaction_instructions(instructions, accounts, None);
         result.run_checks(checks, &self.config, self);
         result
     }
@@ -1957,7 +1946,7 @@ impl<AS: AccountStore> MolluskContext<AS> {
         let accounts = self.load_accounts_for_instructions(instructions.iter());
         let result = self
             .mollusk
-            .process_transaction_instructions(instructions, &accounts);
+            .process_transaction_instructions(instructions, &accounts, None);
         self.consume_transaction_result(&result);
         result
     }

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -1323,6 +1323,20 @@ impl Mollusk {
 
     /// Process multiple instructions using a single shared transaction context.
     ///
+    /// This is the same as
+    /// [`Self::process_transaction_instructions_with_payer`], but without a
+    /// payer. In this case, the payer is assumed to be the first account in the
+    /// `accounts` slice.
+    pub fn process_transaction_instructions(
+        &self,
+        instructions: &[Instruction],
+        accounts: &[(Pubkey, Account)],
+    ) -> TransactionResult {
+        self.process_transaction_instructions_with_payer(instructions, accounts, None)
+    }
+
+    /// Process multiple instructions using a single shared transaction context.
+    ///
     /// This API is the closest Mollusk offers to a transaction. All
     /// instructions are processed in the same message using the same
     /// transaction context. The result is atomic, meaning resulting accounts
@@ -1337,10 +1351,11 @@ impl Mollusk {
     /// * `program_result`: The result code of the last program's execution and
     ///   its index.
     /// * `resulting_accounts`: The resulting accounts after all instructions.
-    pub fn process_transaction_instructions(
+    pub fn process_transaction_instructions_with_payer(
         &self,
         instructions: &[Instruction],
         accounts: &[(Pubkey, Account)],
+        payer: Option<&Pubkey>,
     ) -> TransactionResult {
         let fallback_accounts = self.get_account_fallbacks(
             instructions.iter().map(|ix| &ix.program_id),
@@ -1348,11 +1363,13 @@ impl Mollusk {
             accounts,
         );
 
-        let (sanitized_message, transaction_accounts) = crate::compile_accounts::compile_accounts(
-            instructions,
-            accounts.iter(),
-            &fallback_accounts,
-        );
+        let (sanitized_message, transaction_accounts) =
+            crate::compile_accounts::compile_accounts_with_payer(
+                instructions,
+                accounts.iter(),
+                &fallback_accounts,
+                payer,
+            );
 
         let mut transaction_context =
             self.create_transaction_context(transaction_accounts, instructions.len());

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -1508,6 +1508,9 @@ impl Mollusk {
     /// Process multiple instructions using a single shared transaction context,
     /// then perform checks on the result. Panics if any checks fail.
     ///
+    /// When a transaction fee `payer` is not provided, it is assumed to be the
+    /// first account in the `accounts` slice.
+    ///
     /// This API is the closest Mollusk offers to a transaction. All
     /// instructions are processed in the same message using the same
     /// transaction context. The result is atomic, meaning resulting accounts
@@ -1527,8 +1530,9 @@ impl Mollusk {
         instructions: &[Instruction],
         accounts: &[(Pubkey, Account)],
         checks: &[Check],
+        payer: Option<&Pubkey>,
     ) -> TransactionResult {
-        let result = self.process_transaction_instructions(instructions, accounts, None);
+        let result = self.process_transaction_instructions(instructions, accounts, payer);
         result.run_checks(checks, &self.config, self);
         result
     }
@@ -1942,11 +1946,12 @@ impl<AS: AccountStore> MolluskContext<AS> {
     pub fn process_transaction_instructions(
         &self,
         instructions: &[Instruction],
+        payer: Option<&Pubkey>,
     ) -> TransactionResult {
         let accounts = self.load_accounts_for_instructions(instructions.iter());
         let result = self
             .mollusk
-            .process_transaction_instructions(instructions, &accounts, None);
+            .process_transaction_instructions(instructions, &accounts, payer);
         self.consume_transaction_result(&result);
         result
     }
@@ -1958,12 +1963,14 @@ impl<AS: AccountStore> MolluskContext<AS> {
         &self,
         instructions: &[Instruction],
         checks: &[Check],
+        payer: Option<&Pubkey>,
     ) -> TransactionResult {
         let accounts = self.load_accounts_for_instructions(instructions.iter());
         let result = self.mollusk.process_and_validate_transaction_instructions(
             instructions,
             &accounts,
             checks,
+            payer,
         );
         self.consume_transaction_result(&result);
         result

--- a/harness/tests/instructions_sysvar.rs
+++ b/harness/tests/instructions_sysvar.rs
@@ -185,6 +185,7 @@ fn test_transaction_instructions() {
         &[instruction1, instruction2, instruction3],
         &accounts,
         &[Check::success()],
+        None,
     );
 
     // Verify entries were written for each instruction.

--- a/harness/tests/transaction_instructions.rs
+++ b/harness/tests/transaction_instructions.rs
@@ -159,6 +159,7 @@ fn test_compute_units_tracked() {
             (sender, system_account_with_lamports(1000)),
             (recipient, system_account_with_lamports(0)),
         ],
+        None,
     );
 
     assert_eq!(result.compute_units_consumed, 150);
@@ -182,6 +183,7 @@ fn test_compute_units_accumulate_across_instructions() {
             (bob, system_account_with_lamports(0)),
             (carol, system_account_with_lamports(0)),
         ],
+        None,
     );
 
     assert_eq!(
@@ -212,6 +214,7 @@ fn test_failure_stops_instruction_chain() {
             (bob, system_account_with_lamports(0)),
             (carol, system_account_with_lamports(0)),
         ],
+        None,
     );
 
     assert!(result.program_result.is_err());
@@ -240,6 +243,7 @@ fn test_missing_signer_fails() {
             (sender, system_account_with_lamports(1_000_000)),
             (recipient, system_account_with_lamports(0)),
         ],
+        None,
     );
 
     assert!(result.program_result.is_err());
@@ -267,7 +271,7 @@ fn test_many_instructions_in_transaction() {
         accounts.push((*recipient, system_account_with_lamports(0)));
     }
 
-    let result = mollusk.process_transaction_instructions(&instructions, &accounts);
+    let result = mollusk.process_transaction_instructions(&instructions, &accounts, None);
 
     assert!(result.program_result.is_ok());
 
@@ -292,7 +296,7 @@ fn test_transfers_with_absent_payer_account() {
     let initial_balance = 1_000;
     let transfer_amount = 100;
 
-    let result = mollusk.process_transaction_instructions_with_payer(
+    let result = mollusk.process_transaction_instructions(
         &[solana_system_interface::instruction::transfer(
             &sender,
             &recipient,
@@ -335,7 +339,7 @@ fn test_transfers_with_existing_payer_account() {
     let initial_balance = 1_000;
     let transfer_amount = 100;
 
-    let result = mollusk.process_transaction_instructions_with_payer(
+    let result = mollusk.process_transaction_instructions(
         &[solana_system_interface::instruction::transfer(
             &payer,
             &recipient,

--- a/harness/tests/transaction_instructions.rs
+++ b/harness/tests/transaction_instructions.rs
@@ -281,3 +281,92 @@ fn test_many_instructions_in_transaction() {
         Some(initial_balance - (transfer_amount * 10))
     );
 }
+
+#[test]
+fn test_transfers_with_absent_payer_account() {
+    let mollusk = Mollusk::default();
+
+    let payer = Pubkey::new_unique();
+    let sender = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let initial_balance = 1_000;
+    let transfer_amount = 100;
+
+    let result = mollusk.process_transaction_instructions_with_payer(
+        &[solana_system_interface::instruction::transfer(
+            &sender,
+            &recipient,
+            transfer_amount,
+        )],
+        &[
+            (sender, system_account_with_lamports(initial_balance)),
+            (recipient, system_account_with_lamports(0)),
+        ],
+        Some(&payer),
+    );
+
+    assert!(result.program_result.is_ok());
+
+    assert_eq!(
+        result
+            .resulting_accounts
+            .iter()
+            .find(|(pubkey, _)| pubkey == &sender)
+            .map(|(_, account)| account.lamports),
+        Some(initial_balance - transfer_amount),
+    );
+
+    assert_eq!(
+        result
+            .resulting_accounts
+            .iter()
+            .find(|(pubkey, _)| pubkey == &recipient)
+            .map(|(_, account)| account.lamports),
+        Some(transfer_amount),
+    );
+}
+
+#[test]
+fn test_transfers_with_existing_payer_account() {
+    let mollusk = Mollusk::default();
+
+    let payer = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let initial_balance = 1_000;
+    let transfer_amount = 100;
+
+    let result = mollusk.process_transaction_instructions_with_payer(
+        &[solana_system_interface::instruction::transfer(
+            &payer,
+            &recipient,
+            transfer_amount,
+        )],
+        &[
+            (payer, system_account_with_lamports(initial_balance)),
+            (recipient, system_account_with_lamports(0)),
+        ],
+        Some(&payer),
+    );
+
+    assert!(result.program_result.is_ok());
+    // If the account for the payer is not provided, a default account
+    // will be used for the payer, which will not have enough lamports
+    // to complete the transfer.
+    assert_eq!(
+        result
+            .resulting_accounts
+            .iter()
+            .find(|(pubkey, _)| pubkey == &payer)
+            .map(|(_, account)| account.lamports),
+        Some(initial_balance - transfer_amount),
+    );
+
+    assert_eq!(
+        result
+            .resulting_accounts
+            .iter()
+            .find(|(pubkey, _)| pubkey == &recipient)
+            .map(|(_, account)| account.lamports),
+        Some(transfer_amount),
+    );
+}

--- a/harness/tests/transaction_instructions.rs
+++ b/harness/tests/transaction_instructions.rs
@@ -40,6 +40,7 @@ fn test_transfers_with_persisted_state() {
             Check::account(&intermediary).lamports(0).build(),
             Check::account(&recipient).lamports(transfer_amount).build(),
         ],
+        None,
     );
 }
 
@@ -87,6 +88,7 @@ fn test_multi_program_transaction() {
                 .owner(&program_id)
                 .build(),
         ],
+        None,
     );
 }
 
@@ -127,6 +129,7 @@ fn test_inner_instructions_attributed_to_instruction() {
             (recipient, system_account_with_lamports(0)),
             keyed_account_for_system_program(),
         ],
+        None,
     );
 
     assert!(result.raw_result.is_ok());


### PR DESCRIPTION
### Problem

As noted in https://github.com/febo/abiv2/pull/2, the transaction fee payer in ABIv2 is accessible to programs without being included in instructions directly. This allows programs to optimize signer validation by not requiring an `AccountMeta` for the signer, since the fee payer is always a signer. Currently this is not possible bacause there is no way to specify the fee payer account.

### Solution

Update `process_transaction_instructions*` helpers to accept a payer address. Decided to add to only the `process_transaction*` given that the payer represents the transaction fee payer.

Fixes #283

cc: @deanmlittle 