### PR TITLE
ci: enable ci on abiv2 branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Main
 
 on:
   push:
-    branches: [main, agave-4.0, agave-4.0-rectify]
+    branches: [main, agave-4.0, agave-4.0-rectify, abiv2]
   pull_request:
-    branches: [main, agave-4.0, agave-4.0-rectify]
+    branches: [main, agave-4.0, agave-4.0-rectify, abiv2]
 
 env: {}
 


### PR DESCRIPTION
### Problem

Currently, CI is not running on the abiv2 branch.

### Solution

Update the workflow to include abiv2 branch.