### PR TITLE
ci: Fix version in abiv2 branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm"
-version = "0.14.0-agave-4.2.0-beta.0"
+version = "0.14.0-abiv2"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-bencher"
-version = "0.14.0-agave-4.2.0-beta.0"
+version = "0.14.0-abiv2"
 dependencies = [
  "chrono",
  "mollusk-svm",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-cli"
-version = "0.14.0-agave-4.2.0-beta.0"
+version = "0.14.0-abiv2"
 dependencies = [
  "chrono",
  "clap",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-error"
-version = "0.14.0-agave-4.2.0-beta.0"
+version = "0.14.0-abiv2"
 dependencies = [
  "solana-pubkey 4.2.0",
  "thiserror 2.0.19",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-fuzz-fixture"
-version = "0.14.0-agave-4.2.0-beta.0"
+version = "0.14.0-abiv2"
 dependencies = [
  "agave-feature-set",
  "mollusk-svm-fuzz-fs",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-fuzz-fixture-firedancer"
-version = "0.14.0-agave-4.2.0-beta.0"
+version = "0.14.0-abiv2"
 dependencies = [
  "agave-feature-set",
  "mollusk-svm-fuzz-fs",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-fuzz-fs"
-version = "0.14.0-agave-4.2.0-beta.0"
+version = "0.14.0-abiv2"
 dependencies = [
  "bs58",
  "prost",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-programs-memo"
-version = "0.14.0-agave-4.2.0-beta.0"
+version = "0.14.0-abiv2"
 dependencies = [
  "mollusk-svm",
  "solana-account",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-programs-token"
-version = "0.14.0-agave-4.2.0-beta.0"
+version = "0.14.0-abiv2"
 dependencies = [
  "mollusk-svm",
  "mollusk-svm-programs-token-2022",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-programs-token-2022"
-version = "0.14.0-agave-4.2.0-beta.0"
+version = "0.14.0-abiv2"
 dependencies = [
  "mollusk-svm",
  "solana-account",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-result"
-version = "0.14.0-agave-4.2.0-beta.0"
+version = "0.14.0-abiv2"
 dependencies = [
  "mollusk-svm-fuzz-fixture",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,17 +30,17 @@ criterion = "0.8.2"
 hex = "0.4.3"
 ed25519-dalek = "=2.1.1"
 libsecp256k1 = "0.7.2"
-mollusk-svm = { path = "harness", version = "0.14.0-agave-4.2.0-beta.0" }
-mollusk-svm-bencher = { path = "bencher", version = "0.14.0-agave-4.2.0-beta.0" }
-mollusk-svm-cli = { path = "cli", version = "0.14.0-agave-4.2.0-beta.0" }
-mollusk-svm-error = { path = "error", version = "0.14.0-agave-4.2.0-beta.0" }
-mollusk-svm-fuzz-fixture = { path = "fuzz/fixture", version = "0.14.0-agave-4.2.0-beta.0" }
-mollusk-svm-fuzz-fixture-firedancer = { path = "fuzz/fixture-fd", version = "0.14.0-agave-4.2.0-beta.0" }
-mollusk-svm-fuzz-fs = { path = "fuzz/fs", version = "0.14.0-agave-4.2.0-beta.0" }
-mollusk-svm-programs-memo = { path = "programs/memo", version = "0.14.0-agave-4.2.0-beta.0" }
-mollusk-svm-result = { path = "result", version = "0.14.0-agave-4.2.0-beta.0" }
-mollusk-svm-programs-token = { path = "programs/token", version = "0.14.0-agave-4.2.0-beta.0" }
-mollusk-svm-programs-token-2022 = { path = "programs/token-2022", version = "0.14.0-agave-4.2.0-beta.0" }
+mollusk-svm = { path = "harness", version = "0.14.0-abiv2" }
+mollusk-svm-bencher = { path = "bencher", version = "0.14.0-abiv2" }
+mollusk-svm-cli = { path = "cli", version = "0.14.0-abiv2" }
+mollusk-svm-error = { path = "error", version = "0.14.0-abiv2" }
+mollusk-svm-fuzz-fixture = { path = "fuzz/fixture", version = "0.14.0-abiv2" }
+mollusk-svm-fuzz-fixture-firedancer = { path = "fuzz/fixture-fd", version = "0.14.0-abiv2" }
+mollusk-svm-fuzz-fs = { path = "fuzz/fs", version = "0.14.0-abiv2" }
+mollusk-svm-programs-memo = { path = "programs/memo", version = "0.14.0-abiv2" }
+mollusk-svm-result = { path = "result", version = "0.14.0-abiv2" }
+mollusk-svm-programs-token = { path = "programs/token", version = "0.14.0-abiv2" }
+mollusk-svm-programs-token-2022 = { path = "programs/token-2022", version = "0.14.0-abiv2" }
 num-format = "0.4.4"
 openssl = "0.10.78"
 prost = "0.14"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /usr/bin/env bash
 NIGHTLY_TOOLCHAIN := nightly-2026-04-11
-SOLANA_VERSION := 4.3.0-alpha.0
+SOLANA_VERSION := 4.0.0
 
 
 .PHONY: \


### PR DESCRIPTION
### Problem

PR #277 wrongly updated the solana cli version to `4.3.0-alpha.0`, which does not exist. It also update the workspace version to `0.14.0-abiv2` but did not change the individual crate versions in the dependency list.

### Solution

Update the version to the latest `4.2.0-rc.0` and fix the version of each individual crate.

Note: the "Rustfmt" error on CI is expected – it is fixed in #289