### PR TITLE
abiv2/harness: Fix formatting

### DIFF
--- a/harness/src/program.rs
+++ b/harness/src/program.rs
@@ -244,10 +244,7 @@ pub struct Builtin {
 
 impl Builtin {
     fn program_cache_entry(&self) -> Arc<ProgramCacheEntry> {
-        Arc::new(ProgramCacheEntry::new_builtin(
-            0,
-            self.register_fn,
-        ))
+        Arc::new(ProgramCacheEntry::new_builtin(0, self.register_fn))
     }
 }
 


### PR DESCRIPTION
### Problem

When PR #277 was merged, CI was not set up to run on the abiv2 branch and the PR has a formatting error.

### Solution

Fix the formatting error.