### PR TITLE
abiv2: Use agave-runtime abiv2 feature branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 name = "agave-feature-set"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "ahash",
  "solana-epoch-schedule",
@@ -55,7 +55,7 @@ dependencies = [
 [[package]]
 name = "agave-precompiles"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -3068,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder-client-types"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "base64",
  "bs58",
@@ -3226,7 +3226,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -3272,7 +3272,7 @@ checksum = "1517aa49dcfa9cb793ef90e7aac81346d62ca4a546bb1a754030a033e3972e1c"
 [[package]]
 name = "solana-compute-budget"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -3281,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "solana-compute-budget-program"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -3730,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "base64",
  "bincode",
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-callback"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "solana-account",
  "solana-clock",
@@ -4067,12 +4067,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-feature-set"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 
 [[package]]
 name = "solana-svm-log-collector"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "log",
 ]
@@ -4080,12 +4080,12 @@ dependencies = [
 [[package]]
 name = "solana-svm-measure"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 
 [[package]]
 name = "solana-svm-timings"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "solana-svm-type-overrides"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "rand 0.9.4",
 ]
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "solana-syscalls"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "bincode",
  "libsecp256k1",
@@ -4176,7 +4176,7 @@ dependencies = [
 [[package]]
 name = "solana-system-program"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "bincode",
  "log",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status-client-types"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "base64",
  "bincode",
@@ -4343,7 +4343,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "agave-feature-set",
  "bincode",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "solana-zk-elgamal-proof-program"
 version = "4.3.0-alpha.2"
-source = "git+https://github.com/anza-xyz/agave-runtime.git#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
+source = "git+https://github.com/anza-xyz/agave-runtime.git?branch=feat%2Fabiv2#32ff59e23e52e79c61a90bd23fffd700fe4eafc2"
 dependencies = [
  "bytemuck",
  "solana-instruction",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ edition = "2021"
 version = "0.14.0-abiv2"
 
 [workspace.dependencies]
-agave-feature-set = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
-agave-precompiles = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+agave-feature-set = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
+agave-precompiles = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
 bincode = "1.3.3"
 bs58 = "0.5.1"
 chrono = "0.4.44"
@@ -55,10 +55,10 @@ serial_test = "2.0"
 sha2 = "0.10.9"
 solana-account = "4.3.0"
 solana-account-info = "3.1.0"
-solana-bpf-loader-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-bpf-loader-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
 solana-clock = "3.0.1"
-solana-compute-budget = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
-solana-compute-budget-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-compute-budget = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
+solana-compute-budget-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
 solana-cpi = "3.1.0"
 solana-ed25519-program = "3.0.0"
 solana-epoch-rewards = "3.0.0"
@@ -79,7 +79,7 @@ solana-program-entrypoint = "3.1.1"
 solana-program-error = "3.0.0"
 solana-program-option = "3.1.0"
 solana-program-pack = "3.1.0"
-solana-program-runtime = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-program-runtime = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
 solana-pubkey = "4.1.0"
 solana-rent = "4.2.0"
 solana-sdk-ids = "3.1.0"
@@ -87,20 +87,20 @@ solana-secp256k1-program = "3.0.1"
 solana-secp256r1-program = "3.0.0"
 solana-slot-hashes = "3.0.1"
 solana-stake-history = "1.0.0"
-solana-svm-callback = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
-solana-svm-feature-set = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
-solana-svm-log-collector = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
-solana-svm-timings = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
-solana-syscalls = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-svm-callback = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
+solana-svm-feature-set = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
+solana-svm-log-collector = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
+solana-svm-timings = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
+solana-syscalls = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
 solana-system-interface = "3.0"
-solana-system-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-system-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
 solana-sysvar = "4.0.0"
 solana-sysvar-id = "3.1.0"
-solana-transaction-context = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-transaction-context = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
 solana-transaction-error = "3.0.0"
-solana-transaction-status-client-types = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
-solana-vote-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
-solana-zk-elgamal-proof-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git" }
+solana-transaction-status-client-types = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
+solana-vote-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
+solana-zk-elgamal-proof-program = { version = "4.3.0-alpha.0", git = "https://github.com/anza-xyz/agave-runtime.git", branch = "feat/abiv2" }
 spl-associated-token-account-interface = "2.0.0"
 spl-token-2022-interface = "3.0.1"
 spl-token-group-interface = "0.7.2"


### PR DESCRIPTION
### Problem

The agave fork with ABIv2 enabled moved to a feature branch.

### Solution

Update the git dependency to use agave abiv2 feature branch.