### PR TITLE
fix: derive Firedancer fixture CPI stack depth from its feature set

### DIFF
--- a/harness/src/fuzz/firedancer.rs
+++ b/harness/src/fuzz/firedancer.rs
@@ -140,9 +140,10 @@ pub(crate) fn parse_fixture_context(context: &FuzzContext) -> ParsedFixtureConte
         epoch_context,
     } = context;
 
+    let feature_set = epoch_context.feature_set.runtime_features();
     let compute_budget = ComputeBudget {
         compute_unit_limit: *compute_units_available,
-        ..ComputeBudget::new_with_defaults(true)
+        ..ComputeBudget::new_with_defaults(feature_set.raise_cpi_nesting_limit_to_8)
     };
 
     let accounts = accounts
@@ -170,7 +171,7 @@ pub(crate) fn parse_fixture_context(context: &FuzzContext) -> ParsedFixtureConte
     ParsedFixtureContext {
         accounts,
         compute_budget,
-        feature_set: epoch_context.feature_set.runtime_features(),
+        feature_set,
         instruction,
         slot: slot_context.slot,
     }
@@ -300,6 +301,33 @@ pub fn load_firedancer_fixture(
         &fixture.output,
     );
     (parsed, result)
+}
+
+#[test]
+fn test_parse_fixture_context_honors_fixture_feature_set() {
+    // A Firedancer fixture whose feature set does not activate SIMD-0268
+    // (raise_cpi_nesting_limit_to_8) must replay with the instruction stack
+    // depth the real runtime uses for that feature set, not the latest-features
+    // default. This path previously hardcoded the flag to `true`, so a fixture
+    // with the feature inactive replayed with a deeper CPI stack than on-chain.
+    let mut feature_set = SVMFeatureSet::all_enabled();
+    feature_set.raise_cpi_nesting_limit_to_8 = false;
+
+    let instruction = Instruction::new_with_bytes(Pubkey::new_unique(), &[], vec![]);
+    let context = build_fixture_context(
+        &[],
+        &ComputeBudget::new_with_defaults(true),
+        &feature_set,
+        &instruction,
+        0,
+    );
+    let parsed = parse_fixture_context(&context);
+
+    assert_eq!(
+        parsed.compute_budget.max_instruction_stack_depth,
+        ComputeBudget::new_with_defaults(false).max_instruction_stack_depth,
+    );
+    assert!(!parsed.feature_set.raise_cpi_nesting_limit_to_8);
 }
 
 #[test]


### PR DESCRIPTION
## What

`parse_fixture_context` (the Firedancer fixture replay path) rebuilds the `ComputeBudget` with `ComputeBudget::new_with_defaults(true)`, hardcoding the SIMD-0268 (`raise_cpi_nesting_limit_to_8`) flag to active regardless of the fixture's own feature set.

## Why

`new_with_defaults(simd_0268_active)` sets `max_instruction_stack_depth` to 9 (8 nested CPIs) when the flag is on and 5 (4 nested CPIs) when it is off. The fixture's real feature set is available in the same function (`epoch_context.feature_set`) and is used a few lines later for `ParsedFixtureContext.feature_set`, but the compute budget ignored it.

So for any Firedancer fixture where SIMD-0268 is inactive, Mollusk replays with a stack depth of 9 while the agave/Firedancer runtime uses 5. A program performing 5 to 8 nested CPIs fails on-chain with `MaxInstructionStackDepth` but succeeds under Mollusk fixture replay, so conformance silently passes for transactions the real runtime rejects.

The sibling non-Firedancer path already derives the flag from the feature set (`fuzz/fixture/src/context.rs`, `feature_set.is_active(&raise_cpi_nesting_limit_to_8::id())`), with tests asserting `new_with_defaults(false)` gives a depth of 5.

## Change

Derive `raise_cpi_nesting_limit_to_8` from the fixture's feature set (already parsed in the same function) and pass it to `new_with_defaults`. The unrelated `Mollusk::new_inner` default keeps `true` because it enables all features.

## Test

`test_parse_fixture_context_honors_fixture_feature_set` builds a fixture whose feature set does not activate SIMD-0268 and asserts the parsed compute budget matches `ComputeBudget::new_with_defaults(false)` (depth 5). It fails before the change (hardcoded depth 9) and passes after; the existing Firedancer tests still pass.
