### PR TITLE
harness: make loader v1 a default builtin

### DIFF
--- a/harness/src/program.rs
+++ b/harness/src/program.rs
@@ -260,6 +260,11 @@ static BUILTINS: &[Builtin] = &[
         register_fn: solana_system_program::system_processor::Entrypoint::register,
     },
     Builtin {
+        program_id: loader_keys::LOADER_V1,
+        name: "solana_bpf_loader_deprecated_program",
+        register_fn: solana_bpf_loader_program::Entrypoint::register,
+    },
+    Builtin {
         program_id: loader_keys::LOADER_V2,
         name: "solana_bpf_loader_program",
         register_fn: solana_bpf_loader_program::Entrypoint::register,
@@ -267,12 +272,6 @@ static BUILTINS: &[Builtin] = &[
     Builtin {
         program_id: loader_keys::LOADER_V3,
         name: "solana_bpf_loader_upgradeable_program",
-        register_fn: solana_bpf_loader_program::Entrypoint::register,
-    },
-    #[cfg(feature = "all-builtins")]
-    Builtin {
-        program_id: loader_keys::LOADER_V1,
-        name: "solana_bpf_loader_deprecated_program",
         register_fn: solana_bpf_loader_program::Entrypoint::register,
     },
     #[cfg(feature = "all-builtins")]

--- a/harness/tests/program_cache.rs
+++ b/harness/tests/program_cache.rs
@@ -1,0 +1,39 @@
+//! Tests for the program cache.
+
+use {
+    mollusk_svm::{program::loader_keys, result::Check, Mollusk},
+    solana_instruction::Instruction,
+    solana_pubkey::Pubkey,
+};
+
+// The primary test program's no-op instruction.
+const NOOP: &[u8] = &[0];
+
+fn process_noop_under_loader(loader_key: &Pubkey) {
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+
+    let program_id = Pubkey::new_unique();
+    let mut mollusk = Mollusk::default();
+    mollusk.add_program_with_loader(&program_id, "test_program_primary", loader_key);
+
+    mollusk.process_and_validate_instruction(
+        &Instruction::new_with_bytes(program_id, NOOP, vec![]),
+        &[],
+        &[Check::success()],
+    );
+}
+
+#[test]
+fn test_add_program_under_loader_v1() {
+    process_noop_under_loader(&loader_keys::LOADER_V1);
+}
+
+#[test]
+fn test_add_program_under_loader_v2() {
+    process_noop_under_loader(&loader_keys::LOADER_V2);
+}
+
+#[test]
+fn test_add_program_under_loader_v3() {
+    process_noop_under_loader(&loader_keys::LOADER_V3);
+}


### PR DESCRIPTION
There's really no reason this one can't be a default builtin. It shares the same function as the other BPF Loader programs.

I'm also _pretty sure_ this is non-breaking?