### PR TITLE
fix: include return data in fixture hashes

### DIFF
--- a/fuzz/fixture/src/effects.rs
+++ b/fuzz/fixture/src/effects.rs
@@ -71,5 +71,6 @@ pub(crate) fn hash_proto_effects(hasher: &mut Hasher, effects: &ProtoEffects) {
     hasher.hash(&effects.compute_units_consumed.to_le_bytes());
     hasher.hash(&effects.execution_time.to_le_bytes());
     hasher.hash(&effects.program_result.to_le_bytes());
+    hasher.hash(&effects.return_data);
     crate::account::hash_proto_accounts(hasher, &effects.resulting_accounts);
 }

--- a/fuzz/fixture/src/lib.rs
+++ b/fuzz/fixture/src/lib.rs
@@ -152,4 +152,26 @@ mod tests {
             last_hash = new_hash;
         }
     }
+
+    #[test]
+    fn test_hash_includes_return_data() {
+        let mut fixture = Fixture {
+            input: Context {
+                compute_budget: ComputeBudget::new_with_defaults(false),
+                feature_set: FeatureSet::default(),
+                sysvars: Sysvars::default(),
+                program_id: Pubkey::default(),
+                instruction_accounts: vec![],
+                instruction_data: vec![],
+                accounts: vec![],
+            },
+            output: Effects::default(),
+        };
+
+        let hash_without_return_data = produce_hash(&fixture);
+        fixture.output.return_data = vec![1, 2, 3];
+        let hash_with_return_data = produce_hash(&fixture);
+
+        assert_ne!(hash_without_return_data, hash_with_return_data);
+    }
 }


### PR DESCRIPTION
## What

Include `InstrEffects::return_data` when computing deterministic Mollusk fixture hashes.

## Why

Return data was added to fixture effects after deterministic hashing was introduced, but the hash function was not updated.

This meant two otherwise identical fixtures produced the same hash when only their return data differed. Because fixture hashes determine file naming, distinct fixtures could be deduplicated or overwrite one another.

The Firedancer fixture format already includes return data in its equivalent hash.

## Change

Hash `return_data` alongside the other `InstrEffects` fields.

Add a regression test that changes only return data and verifies that the fixture hash also changes.

## Test

- `cargo test -p mollusk-svm-fuzz-fixture`
- `cargo clippy -p mollusk-svm-fuzz-fixture --all-targets -- -D warnings`
- `cargo fmt --all -- --check`