### PR TITLE
fix: correctly set sysvar ixns account is_writable / is_signer flags

### DIFF
--- a/harness/src/compile_accounts.rs
+++ b/harness/src/compile_accounts.rs
@@ -76,11 +76,9 @@ fn build_transaction_accounts(
                 if let Some((_, provided_account)) = accounts.iter().find(|(k, _)| k == key) {
                     return (*key, AccountSharedData::from(provided_account.clone()));
                 }
-                if let Some(fallback) = fallback_accounts.get(key) {
-                    return (*key, AccountSharedData::from(fallback.clone()));
-                }
+                // We will never have a fallback for the Instructions sysvar.
                 let (_, account) =
-                    crate::instructions_sysvar::keyed_account(all_instructions.iter());
+                    crate::instructions_sysvar::keyed_account(message);
                 return (*key, account.into());
             }
 

--- a/harness/src/instructions_sysvar.rs
+++ b/harness/src/instructions_sysvar.rs
@@ -1,22 +1,23 @@
 use {
-    solana_account::Account,
-    solana_instruction::{BorrowedAccountMeta, BorrowedInstruction, Instruction},
-    solana_instructions_sysvar::construct_instructions_data,
-    solana_pubkey::Pubkey,
+    solana_account::Account, solana_instruction::{BorrowedAccountMeta, BorrowedInstruction}, solana_instructions_sysvar::construct_instructions_data, solana_message::SanitizedMessage, solana_pubkey::Pubkey,
 };
 
-pub fn keyed_account<'a>(instructions: impl Iterator<Item = &'a Instruction>) -> (Pubkey, Account) {
+pub fn keyed_account<'a>(message: &SanitizedMessage) -> (Pubkey, Account) {
+    let account_keys = message.account_keys();
     let data = construct_instructions_data(
-        instructions
-            .map(|instruction| BorrowedInstruction {
-                program_id: &instruction.program_id,
+        message.program_instructions_iter()
+            .map(|(program_id, instruction)| BorrowedInstruction {
+                program_id: program_id,
                 accounts: instruction
                     .accounts
                     .iter()
-                    .map(|meta| BorrowedAccountMeta {
-                        pubkey: &meta.pubkey,
-                        is_signer: meta.is_signer,
-                        is_writable: meta.is_writable,
+                    .map(|account_index| {
+                        let account_index = usize::from(*account_index);
+                        BorrowedAccountMeta {
+                            pubkey: account_keys.get(account_index).unwrap(),
+                            is_signer: message.is_signer(account_index),
+                            is_writable: message.is_writable(account_index),
+                        }
                     })
                     .collect(),
                 data: &instruction.data,

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -709,7 +709,6 @@ impl Mollusk {
     fn get_account_fallbacks<'a>(
         &self,
         all_program_ids: impl Iterator<Item = &'a Pubkey>,
-        all_instructions: impl Iterator<Item = &'a Instruction>,
         accounts: &[(Pubkey, Account)],
     ) -> HashMap<Pubkey, Account> {
         // Use a HashSet for fast lookups.
@@ -731,14 +730,6 @@ impl Mollusk {
                 );
             }
         });
-
-        // Instructions sysvar.
-        if !account_keys.contains(&solana_instructions_sysvar::ID) {
-            // Fallback to the actual implementation of the sysvar.
-            let (ix_sysvar_id, ix_sysvar_acct) =
-                crate::instructions_sysvar::keyed_account(all_instructions);
-            fallbacks.insert(ix_sysvar_id, ix_sysvar_acct);
-        }
 
         fallbacks
     }
@@ -1030,7 +1021,6 @@ impl Mollusk {
     ) -> InstructionResult {
         let fallback_accounts = self.get_account_fallbacks(
             std::iter::once(&instruction.program_id),
-            std::iter::once(instruction),
             accounts,
         );
 
@@ -1142,7 +1132,6 @@ impl Mollusk {
 
         let fallback_accounts = self.get_account_fallbacks(
             instructions.iter().map(|ix| &ix.program_id),
-            instructions.iter(),
             accounts,
         );
 
@@ -1193,7 +1182,6 @@ impl Mollusk {
     ) -> TransactionResult {
         let fallback_accounts = self.get_account_fallbacks(
             instructions.iter().map(|ix| &ix.program_id),
-            instructions.iter(),
             accounts,
         );
 
@@ -1324,7 +1312,6 @@ impl Mollusk {
 
         let fallback_accounts = self.get_account_fallbacks(
             instructions.iter().map(|(ix, _)| &ix.program_id),
-            instructions.iter().map(|(ix, _)| *ix),
             accounts,
         );
 

--- a/harness/tests/instructions_sysvar.rs
+++ b/harness/tests/instructions_sysvar.rs
@@ -329,3 +329,80 @@ fn test_override_sysvar_actual() {
     let resulting_ix_sysvar_account = result.get_account(&solana_instructions_sysvar::ID).unwrap();
     assert_eq!(resulting_ix_sysvar_account.data, ix_sysvar_account_data);
 }
+
+#[test]
+fn test_instruction_chain() {
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+
+    let program_id = Pubkey::new_unique();
+    let mollusk = Mollusk::new(&program_id, "test_program_instructions_sysvar");
+
+    let output_pubkey = Pubkey::new_unique();
+    let output_is_signer = false;
+    let output_is_writable = true;
+    let output_space = ENTRY_SIZE;
+    let output_lamports = Rent::default().minimum_balance(output_space);
+
+    // Account is writable in first Instruction but readonly in second.
+    // This makes the Instructions sysvar correctly report the account as writable in the second Instruction.
+    // When the test program checks the sysvar vs its own flags it should fail.
+    let extra_pubkey = Pubkey::new_unique();
+    let extra_is_signer = false;
+
+    let build_instruction = |extra_is_writable: bool| -> Instruction {
+        let input_data = [
+            output_is_signer as u8,
+            output_is_writable as u8,
+            extra_is_signer as u8,
+            extra_is_writable as u8,
+        ];
+        Instruction::new_with_bytes(
+            program_id,
+            &input_data,
+            vec![
+                AccountMeta {
+                    pubkey: output_pubkey,
+                    is_signer: output_is_signer,
+                    is_writable: output_is_writable,
+                },
+                AccountMeta {
+                    pubkey: extra_pubkey,
+                    is_signer: extra_is_signer,
+                    is_writable: extra_is_writable,
+                },
+                AccountMeta::new_readonly(solana_instructions_sysvar::ID, false),
+            ],
+        )
+    };
+
+    let instruction1 = build_instruction(true);
+    let instruction2 = build_instruction(false);
+
+    let accounts = [
+        (
+            output_pubkey,
+            Account::new(output_lamports, output_space, &program_id),
+        ),
+        (extra_pubkey, Account::default()),
+    ];
+
+    let result = mollusk.process_and_validate_instruction_chain(
+        &[
+            (&instruction1, &[Check::success()]),
+            (&instruction2, &[Check::success()]),
+        ],
+        &accounts,
+    );
+
+    // Each chain element is its own transaction, so the current index is
+    // always 0. The last write is from the second instruction.
+    let output_account = result.get_account(&output_pubkey).unwrap();
+    let (written_program_id, written_index, executed) = parse_entry(&output_account.data, 0);
+    assert_eq!(written_program_id, program_id);
+    assert_eq!(written_index, 0);
+    assert!(!executed);
+
+    assert!(result
+        .get_account(&solana_instructions_sysvar::ID)
+        .is_none());
+}


### PR DESCRIPTION
the ixns sysvar in agave uses transaction-level `SVMMessage` trait impls https://github.com/anza-xyz/agave/blob/master/svm/src/account_loader.rs#L653

these return highest txn-level perms (as opposed to per ixn), so if acc is writable in ixn 1, readonly in ixn 2, the `BorrowedInstruction` for 2 will still show acc as writable in 2 (or like, the "effective privilege" for acc instead of the actual intent)

mollusk reads the actual flag on the acc on each ixn https://github.com/anza-xyz/mollusk/blob/main/harness/src/instructions_sysvar.rs#L8

for the transaction-shaped harness processors this will return divergent behavior from same set of ixns put into a txn on mainnet

also make ixns sysvar creation in `build_transaction_accounts` not dead code by removing creation in `get_fallback_accounts`.  
