### PR TITLE
PoC: Account Helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,6 +1915,7 @@ dependencies = [
  "ed25519-dalek 2.1.1",
  "hex",
  "libsecp256k1",
+ "mollusk-svm-accounts",
  "mollusk-svm-error",
  "mollusk-svm-fuzz-fixture",
  "mollusk-svm-fuzz-fixture-firedancer",
@@ -1966,6 +1967,21 @@ dependencies = [
  "solana-transaction-status-client-types",
  "solana-vote-program",
  "solana-zk-elgamal-proof-program",
+]
+
+[[package]]
+name = "mollusk-svm-accounts"
+version = "0.15.1"
+dependencies = [
+ "bincode",
+ "solana-account",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 4.2.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-stake-interface",
+ "spl-token-interface",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "accounts",
     "bencher",
     "cli",
     "error",
@@ -31,6 +32,7 @@ hex = "0.4.3"
 ed25519-dalek = "=2.1.1"
 libsecp256k1 = "0.7.2"
 mollusk-svm = { path = "harness", version = "0.15.1" }
+mollusk-svm-accounts = { path = "accounts", version = "0.15.1" }
 mollusk-svm-bencher = { path = "bencher", version = "0.15.1" }
 mollusk-svm-cli = { path = "cli", version = "0.15.1" }
 mollusk-svm-error = { path = "error", version = "0.15.1" }
@@ -87,6 +89,7 @@ solana-secp256k1-program = "3.0.1"
 solana-secp256r1-program = "3.0.0"
 solana-slot-hashes = "3.0.1"
 solana-stake-history = "1.0.0"
+solana-stake-interface = { version = "4.3.0", features = ["serde"] }
 solana-svm-callback = "4.2.0"
 solana-svm-feature-set = "4.2.0"
 solana-svm-log-collector = "4.2.0"

--- a/accounts/Cargo.toml
+++ b/accounts/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "mollusk-svm-accounts"
+description = "Account setup helpers for the Mollusk SVM harness."
+documentation = "https://docs.rs/mollusk-svm-accounts"
+authors = { workspace = true }
+repository = { workspace = true }
+readme = { workspace = true }
+license-file ={ workspace = true }
+edition = { workspace = true }
+version = { workspace = true }
+
+[dependencies]
+bincode = { workspace = true }
+solana-account = { workspace = true }
+solana-program-option = { workspace = true }
+solana-program-pack = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-rent = { workspace = true }
+solana-sdk-ids = { workspace = true }
+solana-stake-interface = { workspace = true }
+spl-token-interface = { workspace = true }

--- a/accounts/src/lamports.rs
+++ b/accounts/src/lamports.rs
@@ -1,0 +1,15 @@
+use solana_rent::Rent;
+
+pub(crate) enum Lamports {
+    Exactly(u64),
+    RentExempt(Rent),
+}
+
+impl Lamports {
+    pub(crate) fn resolve(&self, space: usize) -> u64 {
+        match self {
+            Self::Exactly(lamports) => *lamports,
+            Self::RentExempt(rent) => rent.minimum_balance(space),
+        }
+    }
+}

--- a/accounts/src/lib.rs
+++ b/accounts/src/lib.rs
@@ -1,0 +1,37 @@
+//! Account setup helpers for Mollusk.
+//!
+//! Each helper is offered through a builder pattern, with methods for the
+//! presumably most common fields tests might set or manipulate.
+//!
+//! Helpers can be built directly from library payloads via `from_state`.
+//!
+//! ```ignore
+//! let alice = Pubkey::new_unique();
+//! let alice_account = System::new(alice);
+//! let bob = Pubkey::new_unique();
+//! let bob_account = System::new(bob).lamports(1_000);
+//! ```
+//!
+//! ```ignore
+//! let alice = Pubkey::new_unique();
+//! let bob = Pubkey::new_unique();
+//!
+//! mollusk.process_instruction(
+//!     &instruction,
+//!     &[
+//!         System::new(alice),
+//!         System::new(bob).lamports(1_000),
+//!     ],
+//! );
+//! ```
+
+mod lamports;
+mod stake;
+mod system;
+mod token;
+
+pub use {
+    stake::Stake,
+    system::System,
+    token::{Mint, TokenAccount},
+};

--- a/accounts/src/stake.rs
+++ b/accounts/src/stake.rs
@@ -1,0 +1,152 @@
+//! Stake accounts.
+
+use {
+    crate::lamports::Lamports,
+    solana_account::Account,
+    solana_pubkey::Pubkey,
+    solana_rent::Rent,
+    solana_stake_interface::{
+        stake_flags::StakeFlags,
+        state::{Delegation, Meta, Stake as StakeState, StakeStateV2},
+    },
+};
+
+/// A stake account.
+///
+/// Defaults to an initialized, undelegated account with no authorities,
+/// funded with the rent-exempt minimum plus whatever stake is delegated.
+pub struct Stake {
+    address: Pubkey,
+    state: StakeStateV2,
+    lamports: Lamports,
+}
+
+impl Stake {
+    /// An initialized stake account.
+    pub fn new(address: Pubkey) -> Self {
+        Self::from_state(address, StakeStateV2::Initialized(Meta::default()))
+    }
+
+    pub fn from_state(address: Pubkey, state: StakeStateV2) -> Self {
+        Self {
+            address,
+            state,
+            lamports: Lamports::RentExempt(Rent::default()),
+        }
+    }
+
+    /// Set the authority permitted to delegate and deactivate the stake.
+    pub fn staker(self, staker: Pubkey) -> Self {
+        self.with_meta(|meta| meta.authorized.staker = staker)
+    }
+
+    /// Set the authority permitted to withdraw from the account.
+    pub fn withdrawer(self, withdrawer: Pubkey) -> Self {
+        self.with_meta(|meta| meta.authorized.withdrawer = withdrawer)
+    }
+
+    /// Delegate to the given vote account.
+    pub fn delegated_to(self, vote_account: Pubkey) -> Self {
+        self.with_delegation(|delegation| delegation.voter_pubkey = vote_account)
+    }
+
+    /// Set the active delegated stake, in lamports.
+    pub fn stake(self, stake: u64) -> Self {
+        self.with_delegation(|delegation| delegation.stake = stake)
+    }
+
+    /// Hold exactly `lamports`, irrespective of rent-exemption.
+    pub fn lamports(mut self, lamports: u64) -> Self {
+        self.lamports = Lamports::Exactly(lamports);
+        self
+    }
+
+    /// Cover the rent-exempt minimum plus the delegated stake, under the
+    /// default rent.
+    pub fn rent_exempt(self) -> Self {
+        self.rent_exempt_with(&Rent::default())
+    }
+
+    /// Cover the rent-exempt minimum under the given `rent`, plus the
+    /// delegated stake.
+    pub fn rent_exempt_with(mut self, rent: &Rent) -> Self {
+        self.lamports = Lamports::RentExempt(rent.clone());
+        self
+    }
+
+    fn with_meta(mut self, f: impl FnOnce(&mut Meta)) -> Self {
+        match &mut self.state {
+            StakeStateV2::Initialized(meta) | StakeStateV2::Stake(meta, _, _) => f(meta),
+            StakeStateV2::Uninitialized | StakeStateV2::RewardsPool => {
+                let mut meta = Meta::default();
+                f(&mut meta);
+                self.state = StakeStateV2::Initialized(meta);
+            }
+        }
+        self
+    }
+
+    fn with_delegation(mut self, f: impl FnOnce(&mut Delegation)) -> Self {
+        let (meta, mut stake, flags) = match self.state {
+            StakeStateV2::Stake(meta, stake, flags) => (meta, stake, flags),
+            StakeStateV2::Initialized(meta) => (meta, StakeState::default(), StakeFlags::empty()),
+            StakeStateV2::Uninitialized | StakeStateV2::RewardsPool => {
+                (Meta::default(), StakeState::default(), StakeFlags::empty())
+            }
+        };
+        f(&mut stake.delegation);
+        self.state = StakeStateV2::Stake(meta, stake, flags);
+        self
+    }
+}
+
+impl From<Stake> for (Pubkey, Account) {
+    fn from(
+        Stake {
+            address,
+            mut state,
+            lamports,
+        }: Stake,
+    ) -> Self {
+        let space = StakeStateV2::size_of();
+        let rent_exempt_reserve = lamports.resolve(space);
+
+        let delegated = match &mut state {
+            StakeStateV2::Stake(meta, stake, _) => {
+                set_reserve(meta, rent_exempt_reserve);
+                stake.delegation.stake
+            }
+            StakeStateV2::Initialized(meta) => {
+                set_reserve(meta, rent_exempt_reserve);
+                0
+            }
+            StakeStateV2::Uninitialized | StakeStateV2::RewardsPool => 0,
+        };
+
+        let lamports = match lamports {
+            Lamports::Exactly(lamports) => lamports,
+            Lamports::RentExempt(_) => rent_exempt_reserve.saturating_add(delegated),
+        };
+
+        let mut data = vec![0u8; space];
+        bincode::serialize_into(&mut data[..], &state).unwrap();
+
+        (
+            address,
+            Account {
+                lamports,
+                data,
+                owner: solana_sdk_ids::stake::id(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+    }
+}
+
+#[allow(deprecated)]
+fn set_reserve(meta: &mut Meta, rent_exempt_reserve: u64) {
+    if meta.rent_exempt_reserve == 0 {
+        meta.rent_exempt_reserve = rent_exempt_reserve;
+    }
+}

--- a/accounts/src/system.rs
+++ b/accounts/src/system.rs
@@ -1,0 +1,68 @@
+use {
+    crate::lamports::Lamports, solana_account::Account, solana_pubkey::Pubkey, solana_rent::Rent,
+};
+
+/// A System account.
+pub struct System {
+    address: Pubkey,
+    lamports: Lamports,
+    space: usize,
+}
+
+impl System {
+    /// A System account at `address`, holding no lamports and no data.
+    pub fn new(address: Pubkey) -> Self {
+        Self {
+            address,
+            lamports: Lamports::Exactly(0),
+            space: 0,
+        }
+    }
+
+    /// Hold exactly `lamports`.
+    pub fn lamports(mut self, lamports: u64) -> Self {
+        self.lamports = Lamports::Exactly(lamports);
+        self
+    }
+
+    /// Allocate `space` zeroed bytes of account data.
+    pub fn space(mut self, space: usize) -> Self {
+        self.space = space;
+        self
+    }
+
+    /// Hold the minimum balance required for rent exemption at this account's
+    /// space, under the default rent.
+    ///
+    /// Use [`System::rent_exempt_with`] if the test overrides
+    /// `Mollusk::sysvars.rent`.
+    pub fn rent_exempt(self) -> Self {
+        self.rent_exempt_with(&Rent::default())
+    }
+
+    /// Hold the minimum balance required for rent exemption at this account's
+    /// space, under the given `rent`.
+    pub fn rent_exempt_with(mut self, rent: &Rent) -> Self {
+        self.lamports = Lamports::RentExempt(rent.clone());
+        self
+    }
+}
+
+impl From<System> for (Pubkey, Account) {
+    fn from(
+        System {
+            address,
+            lamports,
+            space,
+        }: System,
+    ) -> Self {
+        (
+            address,
+            Account::new(
+                lamports.resolve(space),
+                space,
+                &solana_sdk_ids::system_program::id(),
+            ),
+        )
+    }
+}

--- a/accounts/src/token.rs
+++ b/accounts/src/token.rs
@@ -1,0 +1,198 @@
+//! SPL Token accounts.
+
+use {
+    crate::lamports::Lamports,
+    solana_account::Account,
+    solana_program_option::COption,
+    solana_program_pack::Pack,
+    solana_pubkey::Pubkey,
+    solana_rent::Rent,
+    spl_token_interface::state::{Account as TokenState, AccountState, Mint as MintState},
+};
+
+/// An SPL Token account.
+///
+/// Defaults to an initialized, empty account with no mint or owner, funded
+/// with the rent-exempt minimum.
+pub struct TokenAccount {
+    address: Pubkey,
+    state: TokenState,
+    lamports: Lamports,
+}
+
+impl TokenAccount {
+    /// An initialized token account, holding no tokens.
+    pub fn new(address: Pubkey) -> Self {
+        Self::from_state(
+            address,
+            TokenState {
+                state: AccountState::Initialized,
+                ..Default::default()
+            },
+        )
+    }
+
+    pub fn from_state(address: Pubkey, state: TokenState) -> Self {
+        Self {
+            address,
+            state,
+            lamports: Lamports::RentExempt(Rent::default()),
+        }
+    }
+
+    /// Set the mint whose tokens this account holds.
+    pub fn mint(mut self, mint: Pubkey) -> Self {
+        self.state.mint = mint;
+        self
+    }
+
+    /// Set the wallet that owns this token account.
+    pub fn owner(mut self, owner: Pubkey) -> Self {
+        self.state.owner = owner;
+        self
+    }
+
+    /// Hold `amount` tokens.
+    pub fn balance(mut self, amount: u64) -> Self {
+        self.state.amount = amount;
+        self
+    }
+
+    /// Freeze the account.
+    pub fn frozen(mut self) -> Self {
+        self.state.state = AccountState::Frozen;
+        self
+    }
+
+    /// Delegate `amount` tokens to `delegate`.
+    pub fn delegate(mut self, delegate: Pubkey, amount: u64) -> Self {
+        self.state.delegate = COption::Some(delegate);
+        self.state.delegated_amount = amount;
+        self
+    }
+
+    /// Hold exactly `lamports`, rather than the rent-exempt minimum.
+    pub fn lamports(mut self, lamports: u64) -> Self {
+        self.lamports = Lamports::Exactly(lamports);
+        self
+    }
+
+    /// Hold the rent-exempt minimum, under the default rent.
+    pub fn rent_exempt(self) -> Self {
+        self.rent_exempt_with(&Rent::default())
+    }
+
+    /// Hold the rent-exempt minimum under the given `rent`.
+    pub fn rent_exempt_with(mut self, rent: &Rent) -> Self {
+        self.lamports = Lamports::RentExempt(rent.clone());
+        self
+    }
+}
+
+impl From<TokenAccount> for (Pubkey, Account) {
+    fn from(
+        TokenAccount {
+            address,
+            state,
+            lamports,
+        }: TokenAccount,
+    ) -> Self {
+        (address, pack(state, lamports))
+    }
+}
+
+/// An SPL Token mint.
+///
+/// Defaults to an initialized mint with zero supply and zero decimals, funded
+/// with the rent-exempt minimum.
+pub struct Mint {
+    address: Pubkey,
+    state: MintState,
+    lamports: Lamports,
+}
+
+impl Mint {
+    /// An initialized mint with no supply, no decimals, and no authorities.
+    pub fn new(address: Pubkey) -> Self {
+        Self::from_state(
+            address,
+            MintState {
+                is_initialized: true,
+                ..Default::default()
+            },
+        )
+    }
+
+    pub fn from_state(address: Pubkey, state: MintState) -> Self {
+        Self {
+            address,
+            state,
+            lamports: Lamports::RentExempt(Rent::default()),
+        }
+    }
+
+    /// Set the total supply, in base units.
+    pub fn supply(mut self, supply: u64) -> Self {
+        self.state.supply = supply;
+        self
+    }
+
+    /// Set the number of base-10 digits to the right of the decimal place.
+    pub fn decimals(mut self, decimals: u8) -> Self {
+        self.state.decimals = decimals;
+        self
+    }
+
+    /// Set the authority permitted to mint new tokens.
+    pub fn mint_authority(mut self, authority: Pubkey) -> Self {
+        self.state.mint_authority = COption::Some(authority);
+        self
+    }
+
+    /// Set the authority permitted to freeze token accounts.
+    pub fn freeze_authority(mut self, authority: Pubkey) -> Self {
+        self.state.freeze_authority = COption::Some(authority);
+        self
+    }
+
+    /// Hold exactly `lamports`, rather than the rent-exempt minimum.
+    pub fn lamports(mut self, lamports: u64) -> Self {
+        self.lamports = Lamports::Exactly(lamports);
+        self
+    }
+
+    /// Hold the rent-exempt minimum, under the default rent.
+    pub fn rent_exempt(self) -> Self {
+        self.rent_exempt_with(&Rent::default())
+    }
+
+    /// Hold the rent-exempt minimum under the given `rent`.
+    pub fn rent_exempt_with(mut self, rent: &Rent) -> Self {
+        self.lamports = Lamports::RentExempt(rent.clone());
+        self
+    }
+}
+
+impl From<Mint> for (Pubkey, Account) {
+    fn from(
+        Mint {
+            address,
+            state,
+            lamports,
+        }: Mint,
+    ) -> Self {
+        (address, pack(state, lamports))
+    }
+}
+
+fn pack<T: Pack>(state: T, lamports: Lamports) -> Account {
+    let mut data = vec![0u8; T::LEN];
+    T::pack(state, &mut data).unwrap();
+    Account {
+        lamports: lamports.resolve(T::LEN),
+        data,
+        owner: spl_token_interface::id(),
+        executable: false,
+        rent_epoch: 0,
+    }
+}

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -99,6 +99,7 @@ solana-zk-elgamal-proof-program = { workspace = true, features = ["agave-unstabl
 criterion = { workspace = true }
 ed25519-dalek = { workspace = true }
 libsecp256k1 = { workspace = true }
+mollusk-svm-accounts = { workspace = true }
 openssl = { workspace = true }
 rand0-7 = { workspace = true }
 rayon = { workspace = true }

--- a/harness/src/compile_accounts.rs
+++ b/harness/src/compile_accounts.rs
@@ -10,24 +10,34 @@ use {
     std::collections::{HashMap, HashSet},
 };
 
-pub fn compile_accounts<'a>(
+pub fn compile_accounts<'a, 'b>(
     instructions: &[Instruction],
     accounts: impl Iterator<Item = &'a (Pubkey, Account)>,
-    fallback_accounts: &HashMap<Pubkey, Account>,
+    all_program_ids: impl Iterator<Item = &'b Pubkey>,
+    get_loader_key: impl Fn(&Pubkey) -> Pubkey,
 ) -> (SanitizedMessage, Vec<(Pubkey, AccountSharedData)>) {
-    compile_accounts_with_payer(instructions, accounts, fallback_accounts, None)
+    compile_accounts_with_payer(
+        instructions,
+        accounts,
+        all_program_ids,
+        get_loader_key,
+        None,
+    )
 }
 
-pub fn compile_accounts_with_payer<'a>(
+pub fn compile_accounts_with_payer<'a, 'b>(
     instructions: &[Instruction],
     accounts: impl Iterator<Item = &'a (Pubkey, Account)>,
-    fallback_accounts: &HashMap<Pubkey, Account>,
+    all_program_ids: impl Iterator<Item = &'b Pubkey>,
+    get_loader_key: impl Fn(&Pubkey) -> Pubkey,
     payer: Option<&Pubkey>,
 ) -> (SanitizedMessage, Vec<(Pubkey, AccountSharedData)>) {
     let message = Message::new(instructions, payer);
     let sanitized_message = SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()));
 
     let mut accounts: Vec<_> = accounts.collect();
+
+    let fallback_accounts = get_account_fallbacks(all_program_ids, &accounts, get_loader_key);
 
     let payer_account = payer
         .filter(|payer| !accounts.iter().any(|(key, _)| key == *payer))
@@ -41,16 +51,16 @@ pub fn compile_accounts_with_payer<'a>(
         &sanitized_message,
         &accounts,
         instructions,
-        fallback_accounts,
+        &fallback_accounts,
     );
 
     (sanitized_message, transaction_accounts)
 }
 
 // Determine the accounts to fallback to during account compilation.
-pub fn get_account_fallbacks<'a>(
+fn get_account_fallbacks<'a>(
     all_program_ids: impl Iterator<Item = &'a Pubkey>,
-    accounts: &[(Pubkey, Account)],
+    accounts: &[&(Pubkey, Account)],
     get_loader_key: impl Fn(&Pubkey) -> Pubkey,
 ) -> HashMap<Pubkey, Account> {
     // Use a HashSet for fast lookups.

--- a/harness/src/compile_accounts.rs
+++ b/harness/src/compile_accounts.rs
@@ -35,17 +35,10 @@ pub fn compile_accounts_with_payer<'a, 'b>(
     let message = Message::new(instructions, payer);
     let sanitized_message = SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()));
 
-    let mut accounts: Vec<_> = accounts.collect();
+    let accounts: Vec<_> = accounts.collect();
 
-    let fallback_accounts = get_account_fallbacks(all_program_ids, &accounts, get_loader_key);
-
-    let payer_account = payer
-        .filter(|payer| !accounts.iter().any(|(key, _)| key == *payer))
-        .map(|payer| (*payer, Account::default()));
-
-    if let Some(payer_account) = payer_account.as_ref() {
-        accounts.insert(0, payer_account);
-    }
+    let fallback_accounts =
+        get_account_fallbacks(all_program_ids, &accounts, get_loader_key, payer);
 
     let transaction_accounts = build_transaction_accounts(
         &sanitized_message,
@@ -62,6 +55,7 @@ fn get_account_fallbacks<'a>(
     all_program_ids: impl Iterator<Item = &'a Pubkey>,
     accounts: &[&(Pubkey, Account)],
     get_loader_key: impl Fn(&Pubkey) -> Pubkey,
+    payer: Option<&Pubkey>,
 ) -> HashMap<Pubkey, Account> {
     // Use a HashSet for fast lookups.
     let account_keys: HashSet<&Pubkey> = accounts.iter().map(|(key, _)| key).collect();
@@ -82,6 +76,11 @@ fn get_account_fallbacks<'a>(
             );
         }
     });
+
+    // Transaction fee payer.
+    if let Some(payer) = payer.filter(|payer| !account_keys.contains(payer)) {
+        fallbacks.entry(*payer).or_default();
+    }
 
     fallbacks
 }

--- a/harness/src/compile_accounts.rs
+++ b/harness/src/compile_accounts.rs
@@ -10,25 +10,17 @@ use {
     std::collections::{HashMap, HashSet},
 };
 
-pub fn compile_accounts<'a, 'b>(
+pub fn compile_accounts<'a>(
     instructions: &[Instruction],
     accounts: impl Iterator<Item = &'a (Pubkey, Account)>,
-    all_program_ids: impl Iterator<Item = &'b Pubkey>,
     get_loader_key: impl Fn(&Pubkey) -> Pubkey,
 ) -> (SanitizedMessage, Vec<(Pubkey, AccountSharedData)>) {
-    compile_accounts_with_payer(
-        instructions,
-        accounts,
-        all_program_ids,
-        get_loader_key,
-        None,
-    )
+    compile_accounts_with_payer(instructions, accounts, get_loader_key, None)
 }
 
-pub fn compile_accounts_with_payer<'a, 'b>(
+pub fn compile_accounts_with_payer<'a>(
     instructions: &[Instruction],
     accounts: impl Iterator<Item = &'a (Pubkey, Account)>,
-    all_program_ids: impl Iterator<Item = &'b Pubkey>,
     get_loader_key: impl Fn(&Pubkey) -> Pubkey,
     payer: Option<&Pubkey>,
 ) -> (SanitizedMessage, Vec<(Pubkey, AccountSharedData)>) {
@@ -38,7 +30,7 @@ pub fn compile_accounts_with_payer<'a, 'b>(
     let accounts: Vec<_> = accounts.collect();
 
     let fallback_accounts =
-        get_account_fallbacks(all_program_ids, &accounts, get_loader_key, payer);
+        get_account_fallbacks(&sanitized_message, &accounts, get_loader_key, payer);
 
     let transaction_accounts = build_transaction_accounts(
         &sanitized_message,
@@ -51,8 +43,8 @@ pub fn compile_accounts_with_payer<'a, 'b>(
 }
 
 // Determine the accounts to fallback to during account compilation.
-fn get_account_fallbacks<'a>(
-    all_program_ids: impl Iterator<Item = &'a Pubkey>,
+fn get_account_fallbacks(
+    message: &SanitizedMessage,
     accounts: &[&(Pubkey, Account)],
     get_loader_key: impl Fn(&Pubkey) -> Pubkey,
     payer: Option<&Pubkey>,
@@ -63,19 +55,21 @@ fn get_account_fallbacks<'a>(
     let mut fallbacks = HashMap::new();
 
     // Top-level target programs.
-    all_program_ids.for_each(|program_id| {
-        if !account_keys.contains(program_id) {
-            // Fallback to a stub.
-            fallbacks.insert(
-                *program_id,
-                Account {
-                    owner: get_loader_key(program_id),
-                    executable: true,
-                    ..Default::default()
-                },
-            );
-        }
-    });
+    message
+        .program_instructions_iter()
+        .for_each(|(program_id, _)| {
+            if !account_keys.contains(program_id) {
+                // Fallback to a stub.
+                fallbacks.insert(
+                    *program_id,
+                    Account {
+                        owner: get_loader_key(program_id),
+                        executable: true,
+                        ..Default::default()
+                    },
+                );
+            }
+        });
 
     // Transaction fee payer.
     if let Some(payer) = payer.filter(|payer| !account_keys.contains(payer)) {

--- a/harness/src/compile_accounts.rs
+++ b/harness/src/compile_accounts.rs
@@ -47,6 +47,35 @@ pub fn compile_accounts_with_payer<'a>(
     (sanitized_message, transaction_accounts)
 }
 
+// Determine the accounts to fallback to during account compilation.
+pub fn get_account_fallbacks<'a>(
+    all_program_ids: impl Iterator<Item = &'a Pubkey>,
+    accounts: &[(Pubkey, Account)],
+    get_loader_key: impl Fn(&Pubkey) -> Pubkey,
+) -> HashMap<Pubkey, Account> {
+    // Use a HashSet for fast lookups.
+    let account_keys: HashSet<&Pubkey> = accounts.iter().map(|(key, _)| key).collect();
+
+    let mut fallbacks = HashMap::new();
+
+    // Top-level target programs.
+    all_program_ids.for_each(|program_id| {
+        if !account_keys.contains(program_id) {
+            // Fallback to a stub.
+            fallbacks.insert(
+                *program_id,
+                Account {
+                    owner: get_loader_key(program_id),
+                    executable: true,
+                    ..Default::default()
+                },
+            );
+        }
+    });
+
+    fallbacks
+}
+
 fn build_transaction_accounts(
     message: &SanitizedMessage,
     accounts: &[&(Pubkey, Account)],

--- a/harness/src/fuzz/firedancer.rs
+++ b/harness/src/fuzz/firedancer.rs
@@ -69,12 +69,10 @@ fn build_fixture_context(
         DEFAULT_LOADER_KEY
     };
 
-    let (sanitized_message, _transaction_accounts) = compile_accounts(
-        std::slice::from_ref(instruction),
-        accounts.iter(),
-        std::iter::once(&instruction.program_id),
-        |_| loader_key,
-    );
+    let (sanitized_message, _transaction_accounts) =
+        compile_accounts(std::slice::from_ref(instruction), accounts.iter(), |_| {
+            loader_key
+        });
 
     let compiled_ix = sanitized_message.instructions().first().unwrap();
     let instruction_accounts: Vec<InstructionAccount> = compiled_ix

--- a/harness/src/fuzz/firedancer.rs
+++ b/harness/src/fuzz/firedancer.rs
@@ -25,7 +25,6 @@ use {
     solana_pubkey::Pubkey,
     solana_svm_feature_set::SVMFeatureSet,
     solana_transaction_context::instruction_accounts::InstructionAccount,
-    std::collections::HashMap,
 };
 
 static BUILTIN_PROGRAM_IDS: &[Pubkey] = &[
@@ -70,21 +69,11 @@ fn build_fixture_context(
         DEFAULT_LOADER_KEY
     };
 
-    let fallbacks: HashMap<Pubkey, Account> = [(
-        instruction.program_id,
-        Account {
-            owner: loader_key,
-            executable: true,
-            ..Default::default()
-        },
-    )]
-    .into_iter()
-    .collect();
-
     let (sanitized_message, _transaction_accounts) = compile_accounts(
         std::slice::from_ref(instruction),
         accounts.iter(),
-        &fallbacks,
+        std::iter::once(&instruction.program_id),
+        |_| loader_key,
     );
 
     let compiled_ix = sanitized_message.instructions().first().unwrap();

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -707,9 +707,9 @@ impl Mollusk {
 
     // Determine the accounts to fallback to during account compilation.
     fn get_account_fallbacks<'a>(
-        &self,
         all_program_ids: impl Iterator<Item = &'a Pubkey>,
         accounts: &[(Pubkey, Account)],
+        get_loader_key: impl Fn(&Pubkey) -> Pubkey,
     ) -> HashMap<Pubkey, Account> {
         // Use a HashSet for fast lookups.
         let account_keys: HashSet<&Pubkey> = accounts.iter().map(|(key, _)| key).collect();
@@ -723,7 +723,7 @@ impl Mollusk {
                 fallbacks.insert(
                     *program_id,
                     Account {
-                        owner: self.get_loader_key(program_id),
+                        owner: get_loader_key(program_id),
                         executable: true,
                         ..Default::default()
                     },
@@ -1019,8 +1019,11 @@ impl Mollusk {
         instruction: &Instruction,
         accounts: &[(Pubkey, Account)],
     ) -> InstructionResult {
-        let fallback_accounts =
-            self.get_account_fallbacks(std::iter::once(&instruction.program_id), accounts);
+        let fallback_accounts = Self::get_account_fallbacks(
+            std::iter::once(&instruction.program_id),
+            accounts,
+            |program_id| self.get_loader_key(program_id),
+        );
 
         let (sanitized_message, transaction_accounts) = crate::compile_accounts::compile_accounts(
             std::slice::from_ref(instruction),
@@ -1128,8 +1131,11 @@ impl Mollusk {
             ..Default::default()
         };
 
-        let fallback_accounts =
-            self.get_account_fallbacks(instructions.iter().map(|ix| &ix.program_id), accounts);
+        let fallback_accounts = Self::get_account_fallbacks(
+            instructions.iter().map(|ix| &ix.program_id),
+            accounts,
+            |program_id| self.get_loader_key(program_id),
+        );
 
         let sysvar_cache = self.sysvars.setup_sysvar_cache(accounts);
 
@@ -1176,8 +1182,11 @@ impl Mollusk {
         accounts: &[(Pubkey, Account)],
         payer: Option<&Pubkey>,
     ) -> TransactionResult {
-        let fallback_accounts =
-            self.get_account_fallbacks(instructions.iter().map(|ix| &ix.program_id), accounts);
+        let fallback_accounts = Self::get_account_fallbacks(
+            instructions.iter().map(|ix| &ix.program_id),
+            accounts,
+            |program_id| self.get_loader_key(program_id),
+        );
 
         let (sanitized_message, transaction_accounts) =
             crate::compile_accounts::compile_accounts_with_payer(
@@ -1304,8 +1313,11 @@ impl Mollusk {
             ..Default::default()
         };
 
-        let fallback_accounts =
-            self.get_account_fallbacks(instructions.iter().map(|(ix, _)| &ix.program_id), accounts);
+        let fallback_accounts = Self::get_account_fallbacks(
+            instructions.iter().map(|(ix, _)| &ix.program_id),
+            accounts,
+            |program_id| self.get_loader_key(program_id),
+        );
 
         let sysvar_cache = self.sysvars.setup_sysvar_cache(accounts);
 

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -905,17 +905,15 @@ impl Mollusk {
         }
     }
 
-    fn process_instruction_chain_element<'a>(
+    fn process_instruction_chain_element(
         &self,
         instruction: &Instruction,
         accounts: &[(Pubkey, Account)],
-        all_program_ids: impl Iterator<Item = &'a Pubkey>,
         sysvar_cache: &SysvarCache,
     ) -> InstructionResult {
         let (sanitized_message, transaction_accounts) = crate::compile_accounts::compile_accounts(
             std::slice::from_ref(instruction),
             accounts.iter(),
-            all_program_ids,
             |program_id| self.get_loader_key(program_id),
         );
 
@@ -989,7 +987,6 @@ impl Mollusk {
         let (sanitized_message, transaction_accounts) = crate::compile_accounts::compile_accounts(
             std::slice::from_ref(instruction),
             accounts.iter(),
-            std::iter::once(&instruction.program_id),
             |program_id| self.get_loader_key(program_id),
         );
 
@@ -1099,7 +1096,6 @@ impl Mollusk {
             let this_result = self.process_instruction_chain_element(
                 instruction,
                 &composite_result.resulting_accounts,
-                instructions.iter().map(|ix| &ix.program_id),
                 &sysvar_cache,
             );
 
@@ -1142,7 +1138,6 @@ impl Mollusk {
             crate::compile_accounts::compile_accounts_with_payer(
                 instructions,
                 accounts.iter(),
-                instructions.iter().map(|ix| &ix.program_id),
                 |program_id| self.get_loader_key(program_id),
                 payer,
             );
@@ -1270,7 +1265,6 @@ impl Mollusk {
             let this_result = self.process_instruction_chain_element(
                 instruction,
                 &composite_result.resulting_accounts,
-                instructions.iter().map(|(ix, _)| &ix.program_id),
                 &sysvar_cache,
             );
 

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -491,12 +491,7 @@ use {
     solana_syscalls::create_program_runtime_environment,
     solana_transaction_context::transaction::TransactionContext,
     solana_transaction_error::TransactionError,
-    std::{
-        cell::RefCell,
-        collections::{HashMap, HashSet},
-        iter::once,
-        rc::Rc,
-    },
+    std::{cell::RefCell, collections::HashSet, iter::once, rc::Rc},
 };
 #[cfg(feature = "inner-instructions")]
 use {
@@ -910,17 +905,18 @@ impl Mollusk {
         }
     }
 
-    fn process_instruction_chain_element(
+    fn process_instruction_chain_element<'a>(
         &self,
         instruction: &Instruction,
         accounts: &[(Pubkey, Account)],
-        fallback_accounts: &HashMap<Pubkey, Account>,
+        all_program_ids: impl Iterator<Item = &'a Pubkey>,
         sysvar_cache: &SysvarCache,
     ) -> InstructionResult {
         let (sanitized_message, transaction_accounts) = crate::compile_accounts::compile_accounts(
             std::slice::from_ref(instruction),
             accounts.iter(),
-            fallback_accounts,
+            all_program_ids,
+            |program_id| self.get_loader_key(program_id),
         );
 
         let mut transaction_context = self.create_transaction_context(transaction_accounts, 1);
@@ -990,16 +986,11 @@ impl Mollusk {
         instruction: &Instruction,
         accounts: &[(Pubkey, Account)],
     ) -> InstructionResult {
-        let fallback_accounts = crate::compile_accounts::get_account_fallbacks(
-            std::iter::once(&instruction.program_id),
-            accounts,
-            |program_id| self.get_loader_key(program_id),
-        );
-
         let (sanitized_message, transaction_accounts) = crate::compile_accounts::compile_accounts(
             std::slice::from_ref(instruction),
             accounts.iter(),
-            &fallback_accounts,
+            std::iter::once(&instruction.program_id),
+            |program_id| self.get_loader_key(program_id),
         );
 
         let mut transaction_context = self.create_transaction_context(transaction_accounts, 1);
@@ -1102,19 +1093,13 @@ impl Mollusk {
             ..Default::default()
         };
 
-        let fallback_accounts = crate::compile_accounts::get_account_fallbacks(
-            instructions.iter().map(|ix| &ix.program_id),
-            accounts,
-            |program_id| self.get_loader_key(program_id),
-        );
-
         let sysvar_cache = self.sysvars.setup_sysvar_cache(accounts);
 
         for instruction in instructions.iter() {
             let this_result = self.process_instruction_chain_element(
                 instruction,
                 &composite_result.resulting_accounts,
-                &fallback_accounts,
+                instructions.iter().map(|ix| &ix.program_id),
                 &sysvar_cache,
             );
 
@@ -1153,17 +1138,12 @@ impl Mollusk {
         accounts: &[(Pubkey, Account)],
         payer: Option<&Pubkey>,
     ) -> TransactionResult {
-        let fallback_accounts = crate::compile_accounts::get_account_fallbacks(
-            instructions.iter().map(|ix| &ix.program_id),
-            accounts,
-            |program_id| self.get_loader_key(program_id),
-        );
-
         let (sanitized_message, transaction_accounts) =
             crate::compile_accounts::compile_accounts_with_payer(
                 instructions,
                 accounts.iter(),
-                &fallback_accounts,
+                instructions.iter().map(|ix| &ix.program_id),
+                |program_id| self.get_loader_key(program_id),
                 payer,
             );
 
@@ -1284,19 +1264,13 @@ impl Mollusk {
             ..Default::default()
         };
 
-        let fallback_accounts = crate::compile_accounts::get_account_fallbacks(
-            instructions.iter().map(|(ix, _)| &ix.program_id),
-            accounts,
-            |program_id| self.get_loader_key(program_id),
-        );
-
         let sysvar_cache = self.sysvars.setup_sysvar_cache(accounts);
 
         for (instruction, checks) in instructions.iter() {
             let this_result = self.process_instruction_chain_element(
                 instruction,
                 &composite_result.resulting_accounts,
-                &fallback_accounts,
+                instructions.iter().map(|(ix, _)| &ix.program_id),
                 &sysvar_cache,
             );
 

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -705,35 +705,6 @@ impl Mollusk {
         }
     }
 
-    // Determine the accounts to fallback to during account compilation.
-    fn get_account_fallbacks<'a>(
-        all_program_ids: impl Iterator<Item = &'a Pubkey>,
-        accounts: &[(Pubkey, Account)],
-        get_loader_key: impl Fn(&Pubkey) -> Pubkey,
-    ) -> HashMap<Pubkey, Account> {
-        // Use a HashSet for fast lookups.
-        let account_keys: HashSet<&Pubkey> = accounts.iter().map(|(key, _)| key).collect();
-
-        let mut fallbacks = HashMap::new();
-
-        // Top-level target programs.
-        all_program_ids.for_each(|program_id| {
-            if !account_keys.contains(program_id) {
-                // Fallback to a stub.
-                fallbacks.insert(
-                    *program_id,
-                    Account {
-                        owner: get_loader_key(program_id),
-                        executable: true,
-                        ..Default::default()
-                    },
-                );
-            }
-        });
-
-        fallbacks
-    }
-
     fn create_transaction_context(
         &self,
         transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
@@ -1019,7 +990,7 @@ impl Mollusk {
         instruction: &Instruction,
         accounts: &[(Pubkey, Account)],
     ) -> InstructionResult {
-        let fallback_accounts = Self::get_account_fallbacks(
+        let fallback_accounts = crate::compile_accounts::get_account_fallbacks(
             std::iter::once(&instruction.program_id),
             accounts,
             |program_id| self.get_loader_key(program_id),
@@ -1131,7 +1102,7 @@ impl Mollusk {
             ..Default::default()
         };
 
-        let fallback_accounts = Self::get_account_fallbacks(
+        let fallback_accounts = crate::compile_accounts::get_account_fallbacks(
             instructions.iter().map(|ix| &ix.program_id),
             accounts,
             |program_id| self.get_loader_key(program_id),
@@ -1182,7 +1153,7 @@ impl Mollusk {
         accounts: &[(Pubkey, Account)],
         payer: Option<&Pubkey>,
     ) -> TransactionResult {
-        let fallback_accounts = Self::get_account_fallbacks(
+        let fallback_accounts = crate::compile_accounts::get_account_fallbacks(
             instructions.iter().map(|ix| &ix.program_id),
             accounts,
             |program_id| self.get_loader_key(program_id),
@@ -1313,7 +1284,7 @@ impl Mollusk {
             ..Default::default()
         };
 
-        let fallback_accounts = Self::get_account_fallbacks(
+        let fallback_accounts = crate::compile_accounts::get_account_fallbacks(
             instructions.iter().map(|(ix, _)| &ix.program_id),
             accounts,
             |program_id| self.get_loader_key(program_id),

--- a/harness/tests/accounts.rs
+++ b/harness/tests/accounts.rs
@@ -1,0 +1,111 @@
+//! Tests for the account setup helpers in `mollusk-svm-accounts`.
+
+use {
+    mollusk_svm::{result::Check, Mollusk},
+    mollusk_svm_accounts::{Mint, Stake, System, TokenAccount},
+    solana_instruction::Instruction,
+    solana_pubkey::Pubkey,
+    solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS,
+};
+
+#[test]
+fn test_system_transfer() {
+    let sender = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+
+    let base_lamports = 100_000_000u64;
+    let transfer_amount = 42_000u64;
+
+    Mollusk::default().process_and_validate_instruction(
+        &solana_system_interface::instruction::transfer(&sender, &recipient, transfer_amount),
+        &[
+            System::new(sender).lamports(base_lamports).into(),
+            System::new(recipient).lamports(base_lamports).into(),
+        ],
+        &[
+            Check::success(),
+            Check::compute_units(DEFAULT_COMPUTE_UNITS),
+            Check::account(&sender)
+                .lamports(base_lamports - transfer_amount)
+                .build(),
+            Check::account(&recipient)
+                .lamports(base_lamports + transfer_amount)
+                .build(),
+        ],
+    );
+}
+
+#[test]
+fn test_rent_exemption() {
+    let mollusk = Mollusk::default();
+
+    let sender = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let space = 256usize;
+    let rent_exempt_minimum = mollusk.sysvars.rent.minimum_balance(space);
+    let transfer_amount = 42_000u64;
+
+    mollusk.process_and_validate_instruction(
+        &solana_system_interface::instruction::transfer(&sender, &recipient, transfer_amount),
+        &[
+            System::new(sender).lamports(100_000_000).into(),
+            System::new(recipient).space(space).rent_exempt().into(),
+        ],
+        &[
+            Check::success(),
+            Check::account(&recipient)
+                // TODO: Then here, we could add a new check API for `.rent_exempt_plus(lamports)`
+                .lamports(rent_exempt_minimum + transfer_amount)
+                .space(space)
+                .owner(&solana_sdk_ids::system_program::id())
+                .build(),
+        ],
+    );
+}
+
+#[test]
+fn test_showcase() {
+    std::env::set_var("SBF_OUT_DIR", "../target/deploy");
+    let program_id = Pubkey::new_unique();
+    let mollusk = Mollusk::new(&program_id, "test_program_primary");
+
+    let alice = Pubkey::new_unique();
+    let bob = Pubkey::new_unique();
+    let mint = Pubkey::new_unique();
+    let alice_token_account = Pubkey::new_unique();
+    let alice_stake_account = Pubkey::new_unique();
+    let vote_account = Pubkey::new_unique();
+
+    mollusk.process_and_validate_instruction(
+        &Instruction::new_with_bytes(program_id, &[0], Vec::new()),
+        &[
+            // Alice has 10 SOL. Bob has an empty wallet.
+            System::new(alice).lamports(10_000_000_000).into(),
+            System::new(bob).into(),
+            // A mint with 9 decimals, one billion supply, and Alice holding the
+            // mint authority.
+            Mint::new(mint)
+                .decimals(9)
+                .supply(1_000_000_000)
+                .mint_authority(alice)
+                .rent_exempt()
+                .into(),
+            // Alice holds 1,000 tokens.
+            TokenAccount::new(alice_token_account)
+                .mint(mint)
+                .owner(alice)
+                .balance(1_000)
+                .rent_exempt()
+                .into(),
+            // and has 5 SOL of active stake delegated to a vote account.
+            Stake::new(alice_stake_account)
+                .staker(alice)
+                .withdrawer(alice)
+                .delegated_to(vote_account)
+                .stake(5_000_000_000)
+                .rent_exempt()
+                .into(),
+        ],
+        &[Check::success()],
+    );
+}


### PR DESCRIPTION
Exploring what an account helpers API might look like to improve Mollusk devex.

```rust
mollusk.process_and_validate_instruction(
    &Instruction::new_with_bytes(program_id, &[0], Vec::new()),
    &[
        // Alice has 10 SOL. Bob has an empty wallet.
        System::new(alice).lamports(10_000_000_000).into(),
        System::new(bob).into(),
        // A mint with 9 decimals, one billion supply, and Alice holding the
        // mint authority.
        Mint::new(mint)
            .decimals(9)
            .supply(1_000_000_000)
            .mint_authority(alice)
            .rent_exempt()
            .into(),
        // Alice holds 1,000 tokens.
        TokenAccount::new(alice_token_account)
            .mint(mint)
            .owner(alice)
            .balance(1_000)
            .rent_exempt()
            .into(),
        // and has 5 SOL of active stake delegated to a vote account.
        Stake::new(alice_stake_account)
            .staker(alice)
            .withdrawer(alice)
            .delegated_to(vote_account)
            .stake(5_000_000_000)
            .rent_exempt()
            .into(),
    ],
    &[Check::success()],
);
```