### PR TITLE
ci: use hash-pinned versions for github actions deps

### DIFF
--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - name: Git Checkout
       if: ${{ env.BACKPORT == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         ref: ${{ inputs.base_branch }}
 

--- a/.github/actions/publish-setup/action.yml
+++ b/.github/actions/publish-setup/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v5
+    - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
       with:
         path: |
           ~/.cargo/registry
@@ -28,7 +28,7 @@ runs:
       id: nightly
       shell: bash
       run: echo "version=$(make nightly-version)" >> "$GITHUB_OUTPUT"
-    - uses: dtolnay/rust-toolchain@master
+    - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0  # master
       if: inputs.nightly == 'true'
       with:
         toolchain: ${{ steps.nightly.outputs.version }}
@@ -37,12 +37,12 @@ runs:
       id: solana
       shell: bash
       run: echo "version=$(make solana-version)" >> "$GITHUB_OUTPUT"
-    - uses: metaplex-foundation/actions/install-solana@v1
+    - uses: metaplex-foundation/actions/install-solana@2389940047edc63a5781911f6a53fbdf784748d8  # v1.0.4
       with:
         cache: true
         version: ${{ steps.solana.outputs.version }}
     - name: Install cargo-hack
       if: inputs.cargo-hack == 'true'
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@c3ec0de9ae7f1019cea21aa96aa0a895b9552063  # v2.87.9
       with:
         tool: cargo-hack

--- a/.github/workflows/backport-1.18.yml
+++ b/.github/workflows/backport-1.18.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         
       - name: Backport to v1.18
         uses: ./.github/actions/backport

--- a/.github/workflows/backport-2.0.yml
+++ b/.github/workflows/backport-2.0.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         
       - name: Backport to v2.0
         uses: ./.github/actions/backport

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,11 +13,11 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Get nightly toolchain version
         id: nightly
         run: echo "version=$(make nightly-version)" >> $GITHUB_OUTPUT
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0  # master
         with:
           toolchain: ${{ steps.nightly.outputs.version }}
           components: rustfmt
@@ -30,8 +30,8 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/cache@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -44,7 +44,7 @@ jobs:
       - name: Get nightly toolchain version
         id: nightly
         run: echo "version=$(make nightly-version)" >> $GITHUB_OUTPUT
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0  # master
         with:
           toolchain: ${{ steps.nightly.outputs.version }}
           components: clippy
@@ -57,8 +57,8 @@ jobs:
     name: Check Features
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/cache@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -68,8 +68,8 @@ jobs:
             cargo-hack-
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@v2.85.13
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87  # stable
+      - uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1  # v2.85.13
         with:
           tool: cargo-hack
       - name: Check all feature combinations
@@ -79,8 +79,8 @@ jobs:
     name: Cargo Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/cache@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -93,7 +93,7 @@ jobs:
       - name: Get Solana version
         id: solana
         run: echo "version=$(make solana-version)" >> $GITHUB_OUTPUT
-      - uses: metaplex-foundation/actions/install-solana@v1
+      - uses: metaplex-foundation/actions/install-solana@2389940047edc63a5781911f6a53fbdf784748d8  # v1.0.4
         with:
           cache: true
           version: ${{ steps.solana.outputs.version }}
@@ -106,8 +106,8 @@ jobs:
     name: Audit Rust
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/cache@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -115,7 +115,7 @@ jobs:
           key: cargo-audit-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-audit-
-      - uses: taiki-e/install-action@v2.85.13
+      - uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1  # v2.85.13
         with:
           tool: cargo-audit
       - name: Run cargo-audit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: ./.github/actions/publish-setup
         with:
           nightly: "true"
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Verify crate owners
         shell: bash
         run: make verify-crate-owners
@@ -42,7 +42,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: ./.github/actions/publish-setup
       - name: Dry-run publish
         shell: bash
@@ -62,7 +62,7 @@ jobs:
       artifact-metadata: write
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: ./.github/actions/publish-setup
       - name: Package
         shell: bash


### PR DESCRIPTION
#### Summary of Changes

let's use pinned version for github actions deps 🫡 